### PR TITLE
Add Bindings to Qi

### DIFF
--- a/qi-doc/scribblings/field-guide.scrbl
+++ b/qi-doc/scribblings/field-guide.scrbl
@@ -324,6 +324,7 @@ Another way to do it is to simply promote the expression out of the nest:
     (~> (3) (get-f 1))
   ]
 
+@;{Update this to reflect new partial application behavior}
 Now, you might, once again, expect this to be treated as a partial application template, so that this would be equivalent to @racket[(get-f 3 1)] and would raise an error. But in fact, since the expression @racket[(get-f 1)] happens to be fully qualified with all the arguments it needs, the currying employed under the hood to implement partial application in this case @seclink["Using_Racket_to_Define_Flows"]{evaluates to a function result right away}. This then receives the value @racket[3], and consequently, this expression produces the correct result.
 
 So in sum, it's perhaps best to rely on @racket[esc] in such cases to be as explicit as possible about what you mean, rather than rely on quirks of the implementation that are revealed at this boundary between two languages.

--- a/qi-doc/scribblings/interface.scrbl
+++ b/qi-doc/scribblings/interface.scrbl
@@ -360,19 +360,6 @@ The second way is if you want to describe a flow using the host language instead
     (~> (3 5) add-two)
   ]
 
-Finally, note that the following case works:
-
-@examples[
-    #:eval eval-for-docs
-    (define (get-flow v)
-      (☯ (~> sqr (+ v))))
-    (~> (5) (get-flow 3))
-  ]
-
-You might expect here that the expression @racket[(get-flow 3)] would be treated as a @seclink["Templates_and_Partial_Application"]{partial application template}, so that the value @racket[5] would be provided to it as @racket[(get-flow 5 3)], resulting in an error. The reason this isn't what happens is that the partial application behavior in Qi when no argument positions have been indicated is implemented using currying rather than as a template application, and Racket's @racket[curry] and @racket[curryr] functions happen to evaluate to a result immediately if the maximum expected arguments have been provided. Thus, in this case, the @racket[(get-flow 3)] expression is first evaluated to produce a resulting flow which then receives the value @racket[5].
-
-So, function applications where all of the arguments are provided syntactically, and which produce functions as their result, may be used as if they were simple function identifiers, and @racket[esc] may be left out.
-
 @subsection{Using Racket Macros as Flows}
 
 Flows are expected to be @seclink["What_is_a_Flow_"]{functions}, and so you cannot naively use a macro as a flow. But there are many ways in which you can. If you'd just like to use such a macro in a one-off manner, see @secref["Converting_a_Macro_to_a_Flow"] for an ad hoc way to do this. But a simpler and more complete way in many cases is to first register the macro (or any number of such macros) using @racket[define-qi-foreign-syntaxes] prior to use.

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -42,7 +42,7 @@ in the flow macro.
       ;; error handling catch-all
       [(expr0 expr ...+)
        (report-syntax-error
-        (datum->syntax this-syntax
-          (cons 'flow (syntax->list this-syntax)))
-        "(flow flo)"
-        "flow expects a single flow specification, but it received many.")])))
+           (datum->syntax this-syntax
+             (cons 'flow (syntax->list this-syntax)))
+         "(flow flo)"
+         "flow expects a single flow specification, but it received many.")])))

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(provide (rename-out [flow-interface flow])
+(provide flow
          ☯
          (all-from-out "flow/extended/expander.rkt")
          (all-from-out "flow/extended/forms.rkt"))
@@ -21,7 +21,7 @@
          (only-in "private/util.rkt"
                   define-alias))
 
-(define-alias ☯ flow-interface)
+(define-alias ☯ flow)
 
 #|
 The `flow` macro specifies the Qi language. In cases where there is
@@ -39,18 +39,15 @@ in the flow macro.
 
 (syntax-spec
   (host-interface/expression
-    (flow f:floe)
-    (compile-flow #'f)))
-
-(define-syntax-parser flow-interface
-  ;; we could define `flow` exclusively using syntax-spec if there weren't
-  ;; these extra-linguistic cases to handle. Otherwise, if we did that now,
-  ;; the multi-argument case would only report the intended error message
-  ;; if the component expressions were valid flows
-  [(_ onex) #'(flow onex)]
-  [(_) #'values]
-  [(_ expr0 expr ...+)
-   (report-syntax-error
-    this-syntax
-    "(flow flo)"
-    "flow expects a single flow specification, but it received many.")])
+    (flow f:floe ...)
+    (syntax-parse #'(f ...)
+      [(f) (compile-flow #'f)]
+      ;; a non-flow
+      [() #'values]
+      ;; error handling catch-all
+      [(expr0 expr ...+)
+       (report-syntax-error
+        (datum->syntax this-syntax
+          (cons 'flow (syntax->list this-syntax)))
+        "(flow flo)"
+        "flow expects a single flow specification, but it received many.")])))

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -5,12 +5,7 @@
          (all-from-out "flow/extended/expander.rkt")
          (all-from-out "flow/extended/forms.rkt"))
 
-(require syntax/parse/define
-         syntax-spec
-         (prefix-in fancy: fancy-app)
-         racket/function
-         (only-in racket/list
-                  make-list)
+(require syntax-spec
          (for-syntax racket/base
                      syntax/parse
                      (only-in "private/util.rkt"

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -6,7 +6,7 @@
          (all-from-out "flow/extended/forms.rkt"))
 
 (require syntax/parse/define
-         bindingspec
+         syntax-spec
          (prefix-in fancy: fancy-app)
          racket/function
          (only-in racket/list

--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -10,13 +10,13 @@
 
 (define-syntax-class literal
   (pattern
+   ;; TODO: would be ideal to also match literal vectors, boxes and prefabs
    (~or* expr:boolean
          expr:char
          expr:string
          expr:bytes
          expr:number
          expr:regexp
-         expr:byte-regexp
          ;; We'd like to treat quoted forms as literals as well. This
          ;; includes symbols, and would also include, for instance,
          ;; syntactic specifications of flows, since flows are

--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -17,6 +17,7 @@
          expr:bytes
          expr:number
          expr:regexp
+         expr:byte-regexp
          ;; We'd like to treat quoted forms as literals as well. This
          ;; includes symbols, and would also include, for instance,
          ;; syntactic specifications of flows, since flows are

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -213,10 +213,7 @@
          ;; and need to handle the keyword arguments differently
          ;; from the positional arguments.
          #'(lambda args
-             (let ([f (make-keyword-procedure
-                       (λ (kws kws-vs . pos)
-                         (keyword-apply natex kws kws-vs (append args pos))))])
-               (f prarg ...))))]))
+             ((kw-helper natex args) prarg ...)))]))
 
 ;; The form-specific parsers, which are delegated to from
 ;; the qi0->racket macro:

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -224,7 +224,10 @@
          ;; from the positional arguments.
          #'(lambda args
              ;; (apply natex #,@prarg-kw (append args #,@prarg-pos))
-             (apply natex (append args (list prarg ...)))))]))
+             (let ([f (make-keyword-procedure
+                       (λ (kws kws-vs . pos)
+                         (keyword-apply natex kws kws-vs (append args pos))))])
+               (f prarg ...))))]))
 
 ;; The form-specific parsers, which are delegated to from
 ;; the qi0->racket macro:

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -206,6 +206,7 @@
      ;; curried function will accept any number of arguments
      #:do [(define chirality (syntax-property this-syntax 'chirality))]
      (if (and chirality (eq? chirality 'right))
+         ;; currying quirk with 0 args isn't preserved
          #'(lambda args
              (apply natex (append (list prarg ...) args)))
          #'(lambda args

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -53,6 +53,14 @@
 
 (begin-for-syntax
 
+  (define (extract-kwargs stx)
+    ;; TODO: extract keyword args as (kw val ...)
+    null)
+
+  (define (extract-posargs stx)
+    ;; TODO: extract positional args as (val ...)
+    null)
+
   (define (find-and-map pred f stx)
     (map-transform (λ (v)
                      (cond [(pred v) (f v)]
@@ -205,11 +213,17 @@
      ;; may change under composition within the form), while a
      ;; curried function will accept any number of arguments
      #:do [(define chirality (syntax-property this-syntax 'chirality))]
+     ;; #:with prarg-kw (extract-kwargs #'(prarg ...))
+     ;; #:with prarg-pos (extract-posargs #'(prarg ...))
      (if (and chirality (eq? chirality 'right))
-         ;; currying quirk with 0 args isn't preserved
          #'(lambda args
-             (apply natex (append (list prarg ...) args)))
+             (apply natex prarg ... args))
+         ;; TODO: keyword arguments don't work for the left-chiral case
+         ;; since we can't just blanket place the pre-supplied args
+         ;; and need to handle the keyword arguments differently
+         ;; from the positional arguments.
          #'(lambda args
+             ;; (apply natex #,@prarg-kw (append args #,@prarg-pos))
              (apply natex (append args (list prarg ...)))))]))
 
 ;; The form-specific parsers, which are delegated to from

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -52,14 +52,11 @@
 (begin-for-syntax
 
   (define (find-and-map pred f lst)
-    (if (null? lst)
-        null
-        (let ([v (car lst)]
-              [vs (cdr lst)])
-          (cons (cond [(pred v) (f v)]
-                      [(list? v) (find-and-map pred f v)]
-                      [else v])
-                (find-and-map pred f vs)))))
+    (map (λ (v)
+           (cond [(pred v) (f v)]
+                 [(list? v) (find-and-map pred f v)]
+                 [else v]))
+         lst))
 
   (define (binding-form? stx)
     (and (list? stx) (equal? 'as (car stx))))

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -6,8 +6,7 @@
                      syntax/parse
                      racket/match
                      "syntax.rkt"
-                     "../aux-syntax.rkt"
-                     racket/format)
+                     "../aux-syntax.rkt")
          "impl.rkt"
          racket/function
          racket/undefined

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -53,14 +53,6 @@
 
 (begin-for-syntax
 
-  (define (extract-kwargs stx)
-    ;; TODO: extract keyword args as (kw val ...)
-    null)
-
-  (define (extract-posargs stx)
-    ;; TODO: extract positional args as (val ...)
-    null)
-
   (define (find-and-map pred f stx)
     (map-transform (λ (v)
                      (cond [(pred v) (f v)]
@@ -213,8 +205,6 @@
      ;; may change under composition within the form), while a
      ;; curried function will accept any number of arguments
      #:do [(define chirality (syntax-property this-syntax 'chirality))]
-     ;; #:with prarg-kw (extract-kwargs #'(prarg ...))
-     ;; #:with prarg-pos (extract-posargs #'(prarg ...))
      (if (and chirality (eq? chirality 'right))
          #'(lambda args
              (apply natex prarg ... args))
@@ -223,7 +213,6 @@
          ;; and need to handle the keyword arguments differently
          ;; from the positional arguments.
          #'(lambda args
-             ;; (apply natex #,@prarg-kw (append args #,@prarg-pos))
              (let ([f (make-keyword-procedure
                        (λ (kws kws-vs . pos)
                          (keyword-apply natex kws kws-vs (append args pos))))])

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -21,6 +21,34 @@
   (define (optimize-flow stx)
     stx))
 
+;; Transformation rules for the `as` binding form:
+;;
+;; 1. escape to wrap outermost ~> with let and re-enter
+;;
+;;   (~> flo ... (... (as name) ...))
+;;   ...
+;;    ↓
+;;   ...
+;;   (esc (let ([name (void)])
+;;          (☯ original-flow)))
+;;
+;; 2. as → set!
+;;
+;;   (as name)
+;;   ...
+;;    ↓
+;;   ...
+;;   (~> (esc (λ (x) (set! name x))) ⏚)
+;;
+;; 3. Overall transformation:
+;;
+;;   (~> flo ... (... (as name) ...))
+;;   ...
+;;    ↓
+;;   ...
+;;   (esc (let ([name (void)])
+;;          (☯ (~> flo ... (... (~> (esc (λ (x) (set! name x))) ⏚) ...)))))
+
 (define-syntax (qi0->racket stx)
   (syntax-parse (cadr (syntax->list stx))
 

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -65,6 +65,7 @@
     (and (list? stx) (equal? 'as (car stx))))
 
   ;; (as name) → (~> (esc (λ (x) (set! name x))) ⏚)
+  ;; TODO: use a box instead of set!
   (define (rewrite-binding stx)
     (let ([id (cadr stx)])
       `(~> (esc (λ (x) (set! ,id x))) ⏚)))

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -340,7 +340,9 @@ the DSL.
       [(_ n:expr
           ((~datum then) thenex:clause)
           onex:clause)
-       #'(feedback-times (qi0->racket onex) n (qi0->racket thenex))]
+       #'(lambda args
+           (apply (feedback-times (qi0->racket onex) n (qi0->racket thenex))
+                  args))]
       [(_ n:expr
           ((~datum then) thenex:clause))
        #'(λ (f . args)

--- a/qi-lib/flow/core/impl.rkt
+++ b/qi-lib/flow/core/impl.rkt
@@ -19,7 +19,8 @@
          foldr-values
          values->list
          feedback-times
-         feedback-while)
+         feedback-while
+         kw-helper)
 
 (require racket/match
          (only-in racket/function
@@ -34,6 +35,11 @@
 
 (define-syntax-parse-rule (values->list body:expr ...+)
   (call-with-values (λ () body ...) list))
+
+(define (kw-helper f args)
+  (make-keyword-procedure
+   (λ (kws kws-vs . pos)
+     (keyword-apply f kws kws-vs (append args pos)))))
 
 ;; we use a lambda to capture the arguments at runtime
 ;; since they aren't available at compile time

--- a/qi-lib/flow/core/impl.rkt
+++ b/qi-lib/flow/core/impl.rkt
@@ -24,8 +24,6 @@
 
 (require racket/match
          (only-in racket/function
-                  thunk
-                  thunk*
                   negate)
          racket/bool
          racket/list

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -56,6 +56,10 @@
     tee
     ;; Note: `#:binding nested` is the implicit binding rule here
 
+    (relay f:binding-floe ...)
+    #:binding (nest f nested)
+    relay
+
     ;; [f nested] is the implicit binding rule
     ;; anything not mentioned (e.g. nested) is treated as a
     ;; subexpression that's not in any scope
@@ -79,8 +83,6 @@
     (~> ((~literal _) arg ...) #'(#%fine-template (_ arg ...)))
     _
     ground
-    (relay f:floe ...)
-    relay
     amp
     (amp f:floe)
     (~>/form (amp f0:clause f:clause ...)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -32,17 +32,6 @@
     f:threading-floe
     #:binding (nest-one f []))
 
-  (nonterminal/nesting binding-floe (nested)
-    #:description "a flow expression"
-    #:allow-extension qi-macro
-    #:binding-space qi
-
-    (as v:racket-var ...+)
-    #:binding {(bind v) nested}
-
-    f:threading-floe
-    #:binding (nest-one f nested))
-
   (nonterminal/nesting threading-floe (nested)
     #:description "a flow expression"
     #:allow-extension qi-macro
@@ -61,7 +50,18 @@
     ;; Note: this could be at the top level floe after
     ;; binding-floe, but that isnt supported atm because
     ;; it doesn't backtrack
-    f:simple-floe)
+    _:simple-floe)
+
+  (nonterminal/nesting binding-floe (nested)
+    #:description "a flow expression"
+    #:allow-extension qi-macro
+    #:binding-space qi
+
+    (as v:racket-var ...+)
+    #:binding {(bind v) nested}
+
+    f:threading-floe
+    #:binding (nest-one f nested))
 
   (nonterminal simple-floe
     #:description "a flow expression"

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -32,6 +32,17 @@
     f:threading-floe
     #:binding (nest-one f []))
 
+  (nonterminal/nesting binding-floe (nested)
+    #:description "a flow expression"
+    #:allow-extension qi-macro
+    #:binding-space qi
+
+    (as v:racket-var ...+)
+    #:binding {(bind v) nested}
+
+    f:threading-floe
+    #:binding (nest-one f nested))
+
   (nonterminal/nesting threading-floe (nested)
     #:description "a flow expression"
     #:allow-extension qi-macro
@@ -47,17 +58,6 @@
     ;; binding-floe, but that isnt supported atm because
     ;; it doesn't backtrack
     _:simple-floe)
-
-  (nonterminal/nesting binding-floe (nested)
-    #:description "a flow expression"
-    #:allow-extension qi-macro
-    #:binding-space qi
-
-    (as v:racket-var ...+)
-    #:binding {(bind v) nested}
-
-    f:threading-floe
-    #:binding (nest-one f nested))
 
   (nonterminal simple-floe
     #:description "a flow expression"

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -51,6 +51,11 @@
     (thread f:binding-floe ...)
     #:binding (nest f nested)
 
+    (tee f:binding-floe ...)
+    #:binding (nest f nested)
+    tee
+    ;; Note: `#:binding nested` is the implicit binding rule here
+
     ;; [f nested] is the implicit binding rule
     ;; anything not mentioned (e.g. nested) is treated as a
     ;; subexpression that's not in any scope
@@ -76,8 +81,6 @@
     ground
     (relay f:floe ...)
     relay
-    (tee f:floe ...)
-    tee
     amp
     (amp f:floe)
     (~>/form (amp f0:clause f:clause ...)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -19,164 +19,181 @@
                      syntax/parse
                      "../../private/util.rkt"))
 
-(define-hosted-syntaxes
+(syntax-spec
   ;; Declare a compile-time datatype by which qi macros may
   ;; be identified.
-  (binding-class qi-var)
   (extension-class qi-macro
                    #:binding-space qi)
   (nonterminal floe
-               f:binding-floe
-               #:binding (nest-one f []))
-  (nesting-nonterminal binding-floe (nested)
-                       ;; Check first whether the form is a macro. If it is, expand it.
-                       ;; This is prioritized over other forms so that extensions may
-                       ;; override built-in Qi forms.
-                       #:allow-extension qi-macro
+    f:binding-floe
+    #:binding (nest-one f []))
+  (nonterminal/nesting binding-floe (nested)
+    ;; Check first whether the form is a macro. If it is, expand it.
+    ;; This is prioritized over other forms so that extensions may
+    ;; override built-in Qi forms.
+    #:allow-extension qi-macro
 
-                       #:binding-space qi
+    #:binding-space qi
 
-                       (as v:qi-var ...+)
-                       #:binding {(bind v) nested}
+    (as v:racket-var ...+)
+    #:binding {(bind v) nested}
 
-                       (thread f:binding-floe ...)
-                       #:binding (nest f nested)
+    (thread f:binding-floe ...)
+    #:binding (nest f nested)
 
-                       ;; [f nested] is the implicit binding rule
-                       ;; anything not mentioned (e.g. nested) is treated as a
-                       ;; subexpression that's not in any scope
-                       ;; Note: this could be at the top level floe after
-                       ;; binding-floe, but that isnt supported atm because
-                       ;; it doesn't backtrack
-                       f:simple-floe)
+    ;; [f nested] is the implicit binding rule
+    ;; anything not mentioned (e.g. nested) is treated as a
+    ;; subexpression that's not in any scope
+    ;; Note: this could be at the top level floe after
+    ;; binding-floe, but that isnt supported atm because
+    ;; it doesn't backtrack
+    f:simple-floe)
   (nonterminal simple-floe
-               #:binding-space qi
-               (gen e:expr ...)
-               ;; Ad hoc expansion rule to allow _ to be used in application
-               ;; position in a template.
-               ;; Without it, (_ v ...) would be treated as an error since
-               ;; _ is an unrelated form of the core language having different
-               ;; semantics. The expander would assume it is a syntax error
-               ;; from that perspective.
-               (~> ((~literal _) arg ...) #'(#%fine-template (_ arg ...)))
-               _
-               ground
-               (relay f:floe ...)
-               relay
-               (tee f:floe ...)
-               tee
-               amp
-               (amp f:floe)
-               (~>/form (amp f0:clause f:clause ...)
-                        ;; potentially pull out as a phase 1 function
-                        ;; just a stopgap until better error messages
-                        (report-syntax-error
-                         this-syntax
-                         "(>< flo)"
-                         "amp expects a single flow specification, but it received many."))
-               pass
-               (pass f:floe)
-               sep
-               (sep f:floe)
-               collect
-               AND
-               OR
-               NOT
-               XOR
-               (and f:floe ...)
-               (or f:floe ...)
-               (not f:floe)
-               (select e:expr ...)
-               (~>/form (select arg ...)
-                        (report-syntax-error this-syntax
-                                             "(select <number> ...)"))
-               (block e:expr ...)
-               (~>/form (block arg ...)
-                        (report-syntax-error this-syntax
-                                             "(block <number> ...)"))
-               (group n:expr e1:floe e2:floe)
-               group
-               (~>/form (group arg ...)
-                        (report-syntax-error this-syntax
-                                             "(group <number> <selection flow> <remainder flow>)"))
-               (if consequent:floe
-                   alternative:floe)
-               (if condition:floe
-                   consequent:floe
-                   alternative:floe)
-               (sieve condition:floe
-                      sonex:floe
-                      ronex:floe)
-               sieve
-               (~>/form (sieve arg ...)
-                        (report-syntax-error this-syntax
-                                             "(sieve <predicate flow> <selection flow> <remainder flow>)"))
-               (try flo:floe
-                 [error-condition-flo:floe error-handler-flo:floe]
-                 ...+)
-               (~>/form (try arg ...)
-                        (report-syntax-error this-syntax
-                                             "(try <flo> [error-predicate-flo error-handler-flo] ...)"))
-               >>
-               (>> fn:floe init:floe)
-               (>> fn:floe)
-               <<
-               (<< fn:floe init:floe)
-               (<< fn:floe)
-               (feedback ((~datum while) tilex:floe)
-                         ((~datum then) thenex:floe)
-                         onex:floe)
-               (feedback ((~datum while) tilex:floe)
-                         ((~datum then) thenex:floe))
-               (feedback ((~datum while) tilex:floe) onex:floe)
-               (feedback ((~datum while) tilex:floe))
-               (feedback n:expr
-                         ((~datum then) thenex:floe)
-                         onex:floe)
-               (feedback n:expr
-                         ((~datum then) thenex:floe))
-               (feedback n:expr onex:floe)
-               (feedback onex:floe)
-               feedback
-               (loop pred:floe mapex:floe combex:floe retex:floe)
-               (loop pred:floe mapex:floe combex:floe)
-               (loop pred:floe mapex:floe)
-               (loop mapex:floe)
-               loop
-               (loop2 pred:floe mapex:floe combex:floe)
-               appleye
-               (~> (~literal apply) #'appleye)
-               clos
-               (clos onex:floe)
-               (esc ex:expr)
+    #:binding-space qi
+    (gen e:expr ...)
+    #:binding (host e)
+    ;; Ad hoc expansion rule to allow _ to be used in application
+    ;; position in a template.
+    ;; Without it, (_ v ...) would be treated as an error since
+    ;; _ is an unrelated form of the core language having different
+    ;; semantics. The expander would assume it is a syntax error
+    ;; from that perspective.
+    (~> ((~literal _) arg ...) #'(#%fine-template (_ arg ...)))
+    _
+    ground
+    (relay f:floe ...)
+    relay
+    (tee f:floe ...)
+    tee
+    amp
+    (amp f:floe)
+    (~>/form (amp f0:clause f:clause ...)
+             ;; potentially pull out as a phase 1 function
+             ;; just a stopgap until better error messages
+             (report-syntax-error
+              this-syntax
+              "(>< flo)"
+              "amp expects a single flow specification, but it received many."))
+    pass
+    (pass f:floe)
+    sep
+    (sep f:floe)
+    collect
+    AND
+    OR
+    NOT
+    XOR
+    (and f:floe ...)
+    (or f:floe ...)
+    (not f:floe)
+    (select n:number ...)
+    (~>/form (select arg ...)
+             (report-syntax-error this-syntax
+                                  "(select <number> ...)"))
+    (block n:number ...)
+    (~>/form (block arg ...)
+             (report-syntax-error this-syntax
+                                  "(block <number> ...)"))
+    (group n:expr e1:floe e2:floe)
+    #:binding (host n)
+    group
+    (~>/form (group arg ...)
+             (report-syntax-error this-syntax
+                                  "(group <number> <selection flow> <remainder flow>)"))
+    (if consequent:floe
+        alternative:floe)
+    (if condition:floe
+        consequent:floe
+        alternative:floe)
+    (sieve condition:floe
+           sonex:floe
+           ronex:floe)
+    sieve
+    (~>/form (sieve arg ...)
+             (report-syntax-error this-syntax
+                                  "(sieve <predicate flow> <selection flow> <remainder flow>)"))
+    (try flo:floe
+         [error-condition-flo:floe error-handler-flo:floe]
+         ...+)
+    (~>/form (try arg ...)
+             (report-syntax-error this-syntax
+                                  "(try <flo> [error-predicate-flo error-handler-flo] ...)"))
+    >>
+    (>> fn:floe init:floe)
+    (>> fn:floe)
+    <<
+    (<< fn:floe init:floe)
+    (<< fn:floe)
+    (feedback ((~datum while) tilex:floe)
+              ((~datum then) thenex:floe)
+              onex:floe)
+    (feedback ((~datum while) tilex:floe)
+              ((~datum then) thenex:floe))
+    (feedback ((~datum while) tilex:floe) onex:floe)
+    (feedback ((~datum while) tilex:floe))
+    (feedback n:expr
+              ((~datum then) thenex:floe)
+              onex:floe)
+    #:binding (host n)
+    (feedback n:expr
+              ((~datum then) thenex:floe))
+    #:binding (host n)
+    (feedback n:expr onex:floe)
+    #:binding (host n)
+    (feedback onex:floe)
+    feedback
+    (loop pred:floe mapex:floe combex:floe retex:floe)
+    (loop pred:floe mapex:floe combex:floe)
+    (loop pred:floe mapex:floe)
+    (loop mapex:floe)
+    loop
+    (loop2 pred:floe mapex:floe combex:floe)
+    appleye
+    (~> (~literal apply) #'appleye)
+    clos
+    (clos onex:floe)
+    (esc ex:expr)
+    #:binding (host ex)
 
-               ;; backwards compat macro extensibility via Racket macros
-               (~> ((~var ext-form (starts-with "qi:")) expr ...)
-                   #'(esc (ext-form expr ...)))
-               ;; a literal is interpreted as a flow generating it
-               (~> val:literal
-                   #'(gen val))
-               ;; Certain rules of the language aren't determined by the "head"
-               ;; position, so naively, these can't be core forms. In order to
-               ;; treat them as core forms, we tag them at the expander level
-               ;; by wrapping them with #%-prefixed forms, similar to Racket's
-               ;; approach to a similiar case - "interposition points." These
-               ;; new forms can then be treated as core forms in the compiler.
-               (~> f:blanket-template-form
-                   #'(#%blanket-template f))
-               (#%blanket-template (arg:any-stx ...))
-               (~> f:fine-template-form
-                   #'(#%fine-template f))
-               (#%fine-template (arg:any-stx ...))
-               ;; The core rule must come before the tagging rule here since
-               ;; the former as a production of the latter would still match
-               ;; the latter (i.e. it is still a parenthesized expression),
-               ;; which would lead to infinite code generation.
-               (#%partial-application (arg:any-stx ...))
-               (~> f:partial-application-form
-                   #'(#%partial-application f))
-               ;; literally indicated function identifier
-               (~> f:id #'(esc f))))
+    ;; backwards compat macro extensibility via Racket macros
+    (~> ((~var ext-form (starts-with "qi:")) expr ...)
+        #'(esc (ext-form expr ...)))
+    ;; a literal is interpreted as a flow generating it
+    (~> val:literal
+        #'(gen val))
+    ;; Certain rules of the language aren't determined by the "head"
+    ;; position, so naively, these can't be core forms. In order to
+    ;; treat them as core forms, we tag them at the expander level
+    ;; by wrapping them with #%-prefixed forms, similar to Racket's
+    ;; approach to a similiar case - "interposition points." These
+    ;; new forms can then be treated as core forms in the compiler.
+    (~> f:blanket-template-form
+        #'(#%blanket-template f))
+
+    (#%blanket-template (arg:arg-stx ...))
+
+    (~> f:fine-template-form
+        #'(#%fine-template f))
+    (#%fine-template (arg:arg-stx ...))
+
+    ;; The core rule must come before the tagging rule here since
+    ;; the former as a production of the latter would still match
+    ;; the latter (i.e. it is still a parenthesized expression),
+    ;; which would lead to infinite code generation.
+    (#%partial-application (arg:arg-stx ...))
+
+    (~> f:partial-application-form
+        #'(#%partial-application f))
+    ;; literally indicated function identifier
+    (~> f:id #'(esc f)))
+  
+  (nonterminal arg-stx
+    (~datum _)
+    (~datum __)
+    k:keyword
+    
+    e:expr
+    #:binding (host e)))
 
 (begin-for-syntax
   (define (expand-flow stx)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
-(provide (for-syntax expand-flow
-                     qi-macro)
+(provide (for-syntax qi-macro
+                     floe)
          (for-space qi
                     (all-defined-out)
                     (rename-out [ground ⏚]
@@ -20,14 +20,16 @@
                      "../../private/util.rkt"))
 
 (syntax-spec
-  ;; Declare a compile-time datatype by which qi macros may
-  ;; be identified.
-  (extension-class qi-macro
-                   #:binding-space qi)
+    ;; Declare a compile-time datatype by which qi macros may
+    ;; be identified.
+    (extension-class qi-macro
+                     #:binding-space qi)
   (nonterminal floe
+    #:description "a flow expression"
     f:threading-floe
     #:binding (nest-one f []))
   (nonterminal/nesting binding-floe (nested)
+    #:description "a flow expression"
     ;; Check first whether the form is a macro. If it is, expand it.
     ;; This is prioritized over other forms so that extensions may
     ;; override built-in Qi forms.
@@ -41,6 +43,7 @@
     f:threading-floe
     #:binding (nest-one f nested))
   (nonterminal/nesting threading-floe (nested)
+    #:description "a flow expression"
     ;; Check first whether the form is a macro. If it is, expand it.
     ;; This is prioritized over other forms so that extensions may
     ;; override built-in Qi forms.
@@ -63,6 +66,7 @@
     ;; it doesn't backtrack
     f:simple-floe)
   (nonterminal simple-floe
+    #:description "a flow expression"
     #:binding-space qi
     (gen e:expr ...)
     #:binding (host e)
@@ -127,8 +131,8 @@
              (report-syntax-error this-syntax
                                   "(sieve <predicate flow> <selection flow> <remainder flow>)"))
     (try flo:floe
-         [error-condition-flo:floe error-handler-flo:floe]
-         ...+)
+      [error-condition-flo:floe error-handler-flo:floe]
+      ...+)
     (~>/form (try arg ...)
              (report-syntax-error this-syntax
                                   "(try <flo> [error-predicate-flo error-handler-flo] ...)"))
@@ -200,15 +204,11 @@
         #'(#%partial-application f))
     ;; literally indicated function identifier
     (~> f:id #'(esc f)))
-  
+
   (nonterminal arg-stx
     (~datum _)
     (~datum __)
     k:keyword
-    
+
     e:expr
     #:binding (host e)))
-
-(begin-for-syntax
-  (define (expand-flow stx)
-    ((nonterminal-expander floe) stx)))

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -12,7 +12,7 @@
                                 [sep △]
                                 [collect ▽])))
 
-(require bindingspec
+(require syntax-spec
          (for-syntax "../aux-syntax.rkt"
                      "syntax.rkt"
                      racket/base

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -156,9 +156,7 @@
                (~> f:partial-application-form
                    #'(#%partial-application f))
                ;; literally indicated function identifier
-               ;; TODO: make this id rather than expr once
-               ;; everything else is stable
-               (~> f:expr #'(esc f))))
+               (~> f:id #'(esc f))))
 
 (begin-for-syntax
   (define (expand-flow stx)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -83,10 +83,9 @@
     (~>/form (amp f0:clause f:clause ...)
              ;; potentially pull out as a phase 1 function
              ;; just a stopgap until better error messages
-             (report-syntax-error
-              this-syntax
-              "(>< flo)"
-              "amp expects a single flow specification, but it received many."))
+             (report-syntax-error this-syntax
+               "(>< flo)"
+               "amp expects a single flow specification, but it received many."))
     pass
     (pass f:floe)
     sep
@@ -102,17 +101,17 @@
     (select n:number ...)
     (~>/form (select arg ...)
              (report-syntax-error this-syntax
-                                  "(select <number> ...)"))
+               "(select <number> ...)"))
     (block n:number ...)
     (~>/form (block arg ...)
              (report-syntax-error this-syntax
-                                  "(block <number> ...)"))
+               "(block <number> ...)"))
     (group n:expr e1:floe e2:floe)
     #:binding (host n)
     group
     (~>/form (group arg ...)
              (report-syntax-error this-syntax
-                                  "(group <number> <selection flow> <remainder flow>)"))
+               "(group <number> <selection flow> <remainder flow>)"))
     (if consequent:floe
         alternative:floe)
     (if condition:floe
@@ -124,13 +123,13 @@
     sieve
     (~>/form (sieve arg ...)
              (report-syntax-error this-syntax
-                                  "(sieve <predicate flow> <selection flow> <remainder flow>)"))
+               "(sieve <predicate flow> <selection flow> <remainder flow>)"))
     (try flo:floe
       [error-condition-flo:floe error-handler-flo:floe]
       ...+)
     (~>/form (try arg ...)
              (report-syntax-error this-syntax
-                                  "(try <flo> [error-predicate-flo error-handler-flo] ...)"))
+               "(try <flo> [error-predicate-flo error-handler-flo] ...)"))
     >>
     (>> fn:floe init:floe)
     (>> fn:floe)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -25,7 +25,7 @@
   (extension-class qi-macro
                    #:binding-space qi)
   (nonterminal floe
-    f:binding-floe
+    f:threading-floe
     #:binding (nest-one f []))
   (nonterminal/nesting binding-floe (nested)
     ;; Check first whether the form is a macro. If it is, expand it.
@@ -37,6 +37,20 @@
 
     (as v:racket-var ...+)
     #:binding {(bind v) nested}
+
+    f:threading-floe
+    #:binding (nest-one f nested))
+  (nonterminal/nesting threading-floe (nested)
+    ;; Check first whether the form is a macro. If it is, expand it.
+    ;; This is prioritized over other forms so that extensions may
+    ;; override built-in Qi forms.
+    #:allow-extension qi-macro
+
+    #:binding-space qi
+
+    (~> ((~literal as) v:id ...+)
+        (report-syntax-error this-syntax
+                             "(as ...) may only be used inside ~>"))
 
     (thread f:binding-floe ...)
     #:binding (nest f nested)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -72,8 +72,7 @@
     #:description "a flow expression"
     #:binding-space qi
 
-    (gen e:expr ...)
-    #:binding (host e)
+    (gen e:racket-expr ...)
     ;; Ad hoc expansion rule to allow _ to be used in application
     ;; position in a template.
     ;; Without it, (_ v ...) would be treated as an error since
@@ -111,8 +110,7 @@
     (~>/form (block arg ...)
              (report-syntax-error this-syntax
                "(block <number> ...)"))
-    (group n:expr e1:floe e2:floe)
-    #:binding (host n)
+    (group n:racket-expr e1:floe e2:floe)
     group
     (~>/form (group arg ...)
              (report-syntax-error this-syntax
@@ -148,15 +146,12 @@
               ((~datum then) thenex:floe))
     (feedback ((~datum while) tilex:floe) onex:floe)
     (feedback ((~datum while) tilex:floe))
-    (feedback n:expr
+    (feedback n:racket-expr
               ((~datum then) thenex:floe)
               onex:floe)
-    #:binding (host n)
-    (feedback n:expr
+    (feedback n:racket-expr
               ((~datum then) thenex:floe))
-    #:binding (host n)
-    (feedback n:expr onex:floe)
-    #:binding (host n)
+    (feedback n:racket-expr onex:floe)
     (feedback onex:floe)
     feedback
     (loop pred:floe mapex:floe combex:floe retex:floe)
@@ -169,8 +164,7 @@
     (~> (~literal apply) #'appleye)
     clos
     (clos onex:floe)
-    (esc ex:expr)
-    #:binding (host ex)
+    (esc ex:racket-expr)
 
     ;; backwards compat macro extensibility via Racket macros
     (~> ((~var ext-form (starts-with "qi:")) expr ...)
@@ -209,5 +203,4 @@
     (~datum __)
     k:keyword
 
-    e:expr
-    #:binding (host e)))
+    e:racket-expr))

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -37,10 +37,6 @@
     #:allow-extension qi-macro
     #:binding-space qi
 
-    (~> ((~literal as) v:id ...+)
-        (report-syntax-error this-syntax
-                             "(as ...) may only be used inside ~>"))
-
     (thread f:binding-floe ...)
     #:binding (nest f nested)
 

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -129,6 +129,7 @@
                clos
                (clos onex:floe)
                (esc ex:expr)
+               (as v:id)
                ;; backwards compat macro extensibility via Racket macros
                (~> ((~var ext-form (starts-with "qi:")) expr ...)
                    #'(esc (ext-form expr ...)))

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -28,16 +28,13 @@
 
   (nonterminal floe
     #:description "a flow expression"
+
     f:threading-floe
     #:binding (nest-one f []))
 
   (nonterminal/nesting binding-floe (nested)
     #:description "a flow expression"
-    ;; Check first whether the form is a macro. If it is, expand it.
-    ;; This is prioritized over other forms so that extensions may
-    ;; override built-in Qi forms.
     #:allow-extension qi-macro
-
     #:binding-space qi
 
     (as v:racket-var ...+)
@@ -48,11 +45,7 @@
 
   (nonterminal/nesting threading-floe (nested)
     #:description "a flow expression"
-    ;; Check first whether the form is a macro. If it is, expand it.
-    ;; This is prioritized over other forms so that extensions may
-    ;; override built-in Qi forms.
     #:allow-extension qi-macro
-
     #:binding-space qi
 
     (~> ((~literal as) v:id ...+)
@@ -73,6 +66,7 @@
   (nonterminal simple-floe
     #:description "a flow expression"
     #:binding-space qi
+
     (gen e:expr ...)
     #:binding (host e)
     ;; Ad hoc expansion rule to allow _ to be used in application

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -20,14 +20,17 @@
                      "../../private/util.rkt"))
 
 (syntax-spec
-    ;; Declare a compile-time datatype by which qi macros may
-    ;; be identified.
-    (extension-class qi-macro
-                     #:binding-space qi)
+
+  ;; Declare a compile-time datatype by which qi macros may
+  ;; be identified.
+  (extension-class qi-macro
+                   #:binding-space qi)
+
   (nonterminal floe
     #:description "a flow expression"
     f:threading-floe
     #:binding (nest-one f []))
+
   (nonterminal/nesting binding-floe (nested)
     #:description "a flow expression"
     ;; Check first whether the form is a macro. If it is, expand it.
@@ -42,6 +45,7 @@
 
     f:threading-floe
     #:binding (nest-one f nested))
+
   (nonterminal/nesting threading-floe (nested)
     #:description "a flow expression"
     ;; Check first whether the form is a macro. If it is, expand it.
@@ -65,6 +69,7 @@
     ;; binding-floe, but that isnt supported atm because
     ;; it doesn't backtrack
     f:simple-floe)
+
   (nonterminal simple-floe
     #:description "a flow expression"
     #:binding-space qi

--- a/qi-lib/flow/extended/forms.rkt
+++ b/qi-lib/flow/extended/forms.rkt
@@ -13,8 +13,7 @@
                      syntax/parse
                      (only-in racket/list make-list)
                      "syntax.rkt"
-                     "../aux-syntax.rkt"
-                     "../../private/util.rkt")
+                     "../aux-syntax.rkt")
          "expander.rkt"
          "../../macro.rkt"
          "impl.rkt")

--- a/qi-lib/info.rkt
+++ b/qi-lib/info.rkt
@@ -5,8 +5,8 @@
 (define deps '("base"
                ("fancy-app" #:version "1.1")
                ;; this git URL should be changed to a named package spec
-               ;; once bindingspec is on the package index
-               "git://github.com/michaelballantyne/bindingspec.git#main"))
+               ;; once syntax-spec is on the package index
+               "git://github.com/michaelballantyne/syntax-spec.git#main"))
 (define build-deps '())
 (define clean '("compiled" "private/compiled"))
 (define pkg-authors '(countvajhula))

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -7,14 +7,12 @@
          (for-syntax qi-macro))
 
 (require (for-syntax racket/base
-                     syntax/parse
                      racket/format
                      racket/match
                      racket/list)
          (only-in "flow/extended/expander.rkt"
                   qi-macro
                   esc)
-         racket/format
          syntax/parse/define
          syntax/parse)
 

--- a/qi-lib/switch.rkt
+++ b/qi-lib/switch.rkt
@@ -48,4 +48,4 @@
          expr ...))]
   [(_ name:id expr:expr ...)
    #'(define name
-       (☯ (switch expr ...)))])
+       (flow (switch expr ...)))])

--- a/qi-lib/threading.rkt
+++ b/qi-lib/threading.rkt
@@ -19,9 +19,9 @@
   [(_ (arg0 arg ...+) (~or* (~datum sep) (~datum △)) clause:clause ...)
    ;; catch a common usage error
    (report-syntax-error this-syntax
-                        "(~> (arg ...) flo ...)"
-                        "Attempted to separate multiple values."
-                        "Note that the inputs to ~> must be wrapped in parentheses.")]
+     "(~> (arg ...) flo ...)"
+     "Attempted to separate multiple values."
+     "Note that the inputs to ~> must be wrapped in parentheses.")]
   [(_ args:subject clause:clause ...)
    #:with ags (attribute args.args)
    #'(on ags (~> clause ...))])
@@ -30,9 +30,9 @@
   [(_ (arg0 arg ...+) (~or* (~datum sep) (~datum △)) clause:clause ...)
    ;; catch a common usage error
    (report-syntax-error this-syntax
-                        "(~>> (arg ...) flo ...)"
-                        "Attempted to separate multiple values."
-                        "Note that the inputs to ~>> must be wrapped in parentheses.")]
+     "(~>> (arg ...) flo ...)"
+     "Attempted to separate multiple values."
+     "Note that the inputs to ~>> must be wrapped in parentheses.")]
   [(_ args:subject clause:clause ...)
    #:with ags (attribute args.args)
    #'(on ags (~>> clause ...))])

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -372,19 +372,17 @@
                    (list 1 2 3))
                   (list 1 2 3 1 2 3)
                   "idiom: bind as a side effect")
-    (check-equal? ((☯ (~> (ε (as args)) (append args)))
-                   (list 1 2 3))
-                  (list 1 2 3 1 2 3)
-                  "idiom: bind as a side effect")
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
                        ((☯ (~> (as n) 5 (feedback n add1)))
                         3)))
+               ;; TODO: discuss this
                "using a bound value in a flow specification is an error")
     (check-equal? ((☯ (~> (== (as n) _) sqr (+ n)))
                    3 5)
                   8
                   "binding some but not all values using a relay")
+    ;; TODO: remove / fix
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
                        ((☯ (~> list (-< vs (as vs)))))))
@@ -400,15 +398,15 @@
                   "tee junction tines bind succeeding peers")
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
-                       ((☯ (~> (or (ε (as v)) 5) (+ v)))
-                        3)))
-               "error is raised if identifier is not guaranteed to be bound downstream")
-    (check-exn exn:fail?
-               (thunk (convert-compile-time-error
                        ((☯ (~> (-< (gen v)
                                    (as v))))
                         3)))
                "tee junction tines don't bind preceding peers")
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       ((☯ (~> (or (ε (as v)) 5) (+ v)))
+                        3)))
+               "error is raised if identifier is not guaranteed to be bound downstream")
     (let ([as (lambda (v) v)])
       (check-equal? ((☯ (~> (gen (as 3))))) 3)
       (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -350,6 +350,10 @@
     (check-equal? ((☯ (~> (as v w) (+ v w))) 3 4)
                   7
                   "binds multiple values")
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       ((☯ (~> list (-< vs (as vs)))))))
+               "using `as` outside a threading form is an error")
     ;; convert-compile-time-error
     (check-exn exn:fail?
                (thunk (convert-compile-time-error

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -331,6 +331,11 @@
                     "abc"))))
 
    (test-suite
+    "bindings"
+    (check-equal? ((☯ (~> (as v) (+ v))) 3)
+                  3))
+
+   (test-suite
     "routing forms"
     (test-suite
      "~>"

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -382,11 +382,6 @@
                    3 5)
                   8
                   "binding some but not all values using a relay")
-    ;; TODO: remove / fix
-    (check-exn exn:fail?
-               (thunk (convert-compile-time-error
-                       ((☯ (~> list (-< vs (as vs)))))))
-               "using `as` outside a threading form is an error")
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
                        ((☯ (~> sqr (list v) (as v) (gen v))) 3)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -344,7 +344,10 @@
    (test-suite
     "bindings"
     (check-equal? ((☯ (~> (as v) (+ v))) 3)
-                  3))
+                  3)
+    (let ([as (lambda (v) v)])
+      (check-equal? ((☯ (~> (gen (as 3))))) 3) ; TODO: why does this work?
+      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)))
 
    (test-suite
     "routing forms"

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -345,17 +345,19 @@
    (test-suite
     "bindings"
     (check-equal? ((☯ (~> (as v) (+ v))) 3)
-                  3)
+                  3
+                  "binds a single value")
+    (check-equal? ((☯ (~> (as v w) (+ v w))) 3 4)
+                  7
+                  "binds multiple values")
     ;; convert-compile-time-error
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
                        ((☯ (~> sqr (list v) (as v) (gen v))) 3)))
                "bindings cannot be referenced before being assigned")
     (let ([as (lambda (v) v)])
-      (check-equal? ((☯ (~> (gen (as 3))))) 3) ; TODO: why does this work?
-      ;; TODO: uncomment for bindings
-      ;; (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)
-      ))
+      (check-equal? ((☯ (~> (gen (as 3))))) 3)
+      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)))
 
    (test-suite
     "routing forms"

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -347,7 +347,9 @@
                   3)
     (let ([as (lambda (v) v)])
       (check-equal? ((☯ (~> (gen (as 3))))) 3) ; TODO: why does this work?
-      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)))
+      ;; TODO: uncomment for bindings
+      ;; (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)
+      ))
 
    (test-suite
     "routing forms"
@@ -855,13 +857,13 @@
                    "short-circuiting"))
     (test-suite
      "sieve"
-     (check-equal? ((☯ (~> (sieve positive? add1 (const -1)) ▽))
+     (check-equal? ((☯ (~> (sieve positive? add1 (gen -1)) ▽))
                     1 -2)
                    (list 2 -1))
      (check-equal? ((☯ (~> (sieve positive? + (+ 2)) ▽))
                     1 2 -3 4)
                    (list 7 -1))
-     (check-equal? ((☯ (~> (sieve positive? + (const 0)) ▽))
+     (check-equal? ((☯ (~> (sieve positive? + (gen 0)) ▽))
                     1 2 3 4)
                    (list 10 0))
      (check-equal? ((☯ (~> (sieve negative? ⏚ ⏚) ▽))
@@ -1037,7 +1039,7 @@
                    "pure control form of feedback"))
     (test-suite
      "group"
-     (check-equal? ((☯ (~> (group 0 (const 5) +) ▽))
+     (check-equal? ((☯ (~> (group 0 (gen 5) +) ▽))
                     1 2)
                    (list 5 3))
      (check-equal? ((☯ (~> (group 1 add1 sub1) ▽))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -403,8 +403,8 @@
                         3)))
                "error is raised if identifier is not guaranteed to be bound downstream")
     (let ([as (lambda (v) v)])
-      (check-equal? ((☯ (~> (gen (as 3))))) 3)
-      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3)))
+      (check-equal? ((☯ (~> (gen (as 3))))) 3 "Racket functions named `as` aren't clobbered")
+      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3 "Racket functions named `as` aren't clobbered")))
 
    (test-suite
     "routing forms"

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -55,6 +55,8 @@
      (check-equal? ((flow #"hi") 5) #"hi" "literal byte string")
      (check-equal? ((flow #px"hi") 5) #px"hi" "literal regexp")
      (check-equal? ((flow #rx"hi") 5) #rx"hi" "literal regexp")
+     (check-equal? ((flow #px#"hi") 5) #px#"hi" "bytestring literal regexp")
+     (check-equal? ((flow #rx#"hi") 5) #rx#"hi" "bytestring literal regexp")
      (check-equal? ((flow 'hi) 5) 'hi "literal symbol")
      (check-equal? ((flow '(+ 1 2)) 5) '(+ 1 2) "literal quoted list")
      (check-equal? ((flow `(+ 1 ,(* 2 3))) 5) '(+ 1 6) "literal quasiquoted list")

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -32,9 +32,18 @@
      (check-equal? (values->list ((☯))) null "empty flow with no inputs")
      (check-equal? ((☯) 0) 0 "empty flow with one input")
      (check-equal? (values->list ((☯) 1 2)) (list 1 2) "empty flow with multiple inputs")
-     (check-equal? ((☯ (const 3))) 3 "no arguments")
+     (check-equal? ((☯ (+ 3))) 3 "partial application with no runtime arguments")
      (check-equal? ((flow add1) 2) 3 "simple function")
-     (check-equal? ((flow (get-f 1)) 2) 3 "fully qualified function")
+     (check-exn exn:fail:contract?
+                (thunk ((flow (get-f 1)) 2))
+                "fully qualified function is still treated as a partial application")
+     ;; As this is a syntax error, it can't be written as a unit test
+     ;; (check-exn exn:fail:contract?
+     ;;            (thunk (flow (get-f)))
+     ;;            "empty partial application isn't allowed")
+     (check-equal? ((flow (esc (get-f 1))) 2)
+                   3
+                   "fully qualified function used as a flow must still use esc")
      (check-equal? ((flow _) 5) 5 "identity flow")
      (check-equal? ((flow (~> _ ▽)) 5 6) (list 5 6) "identity flow"))
     (test-suite
@@ -255,6 +264,8 @@
                    (list 3 4 5)))
     (test-suite
      "escape hatch"
+     (check-equal? ((☯ (esc add1)) 2) 3)
+     (check-equal? ((☯ (esc (const 3)))) 3)
      (check-equal? ((☯ (esc (first (list + *)))) 3 7)
                    10
                    "normal racket expressions"))
@@ -586,10 +597,13 @@
                     (list "a" "b" "c"))
                    "cba"
                    "curried foldl")
-     (check-exn exn:fail?
-                (thunk ((☯ (+))
-                        5 7 8))
-                "function isn't curried when no arguments are provided"))
+     (check-equal? (((☯ (const 3)))) 3 "partial application with no arguments")
+     ;; As this is now a syntax error, it can't be written as a unit test
+     ;; (check-exn exn:fail?
+     ;;            (thunk ((☯ (+))
+     ;;                    5 7 8))
+     ;;            "function isn't curried when no arguments are provided")
+     )
     (test-suite
      "blanket template"
      (check-equal? ((☯ (+ __))) 0)

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -380,6 +380,10 @@
                    3 5)
                   28
                   "binding some but not all values using a relay")
+    (check-equal? (map (☯ (~> (as n) (+ n n)))
+                       (list 1 3 5))
+                  (list 2 6 10)
+                  "binding arguments without a lambda")
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
                        ((☯ (~> sqr (list v) (as v) (gen v))) 3)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -361,9 +361,9 @@
                    1 2)
                   "The sum of (1 2) is 3"
                   "bindings are scoped to the outermost threading form")
-    (check-equal? ((☯ (~> (-< _ (~> list (as S)))
-                          (-< sqr (~>> list (append S) (as S)))
+    (check-equal? ((☯ (~> (-< sqr (~> list (as S)))
                           (-< add1 (~>> list (append S) (as S)))
+                          (-< _ (~>> list (append S) (as S)))
                           (list S)))
                    5)
                   (list 26 (list 5 25 26))
@@ -372,15 +372,13 @@
                    (list 1 2 3))
                   (list 1 2 3 1 2 3)
                   "idiom: bind as a side effect")
-    (check-exn exn:fail?
-               (thunk (convert-compile-time-error
-                       ((☯ (~> (as n) 5 (feedback n add1)))
-                        3)))
-               ;; TODO: discuss this
-               "using a bound value in a flow specification is an error")
+    (check-equal? ((☯ (~> (as n) 5 (feedback n add1)))
+                   3)
+                  8
+                  "using a bound value in a flow specification")
     (check-equal? ((☯ (~> (== (as n) _) sqr (+ n)))
                    3 5)
-                  8
+                  28
                   "binding some but not all values using a relay")
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
@@ -403,8 +401,12 @@
                         3)))
                "error is raised if identifier is not guaranteed to be bound downstream")
     (let ([as (lambda (v) v)])
-      (check-equal? ((☯ (~> (gen (as 3))))) 3 "Racket functions named `as` aren't clobbered")
-      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3) 3 "Racket functions named `as` aren't clobbered")))
+      (check-equal? ((☯ (~> (gen (as 3)))))
+                    3
+                    "Racket functions named `as` aren't clobbered")
+      (check-equal? ((☯ (~> (esc (lambda (v) (as v))))) 3)
+                    3
+                    "Racket functions named `as` aren't clobbered")))
 
    (test-suite
     "routing forms"

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -11,7 +11,8 @@
          racket/string
          racket/function
          (except-in "private/util.rkt"
-                    add-two))
+                    add-two)
+         syntax/macro-testing)
 
 ;; used in the "language extension" tests for `qi:*`
 (define-syntax-rule (qi:square flo)
@@ -119,7 +120,7 @@
      (check-true ((☯ (and positive?
                           (or integer?
                               odd?)))
-                  5))
+                 5))
      (check-false ((☯ (and positive?
                            (or (> 6)
                                even?)))
@@ -345,6 +346,11 @@
     "bindings"
     (check-equal? ((☯ (~> (as v) (+ v))) 3)
                   3)
+    ;; convert-compile-time-error
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       ((☯ (~> sqr (list v) (as v) (gen v))) 3)))
+               "bindings cannot be referenced before being assigned")
     (let ([as (lambda (v) v)])
       (check-equal? ((☯ (~> (gen (as 3))))) 3) ; TODO: why does this work?
       ;; TODO: uncomment for bindings

--- a/qi-test/tests/macro.rkt
+++ b/qi-test/tests/macro.rkt
@@ -7,8 +7,7 @@
          rackunit/text-ui
          (only-in math sqr)
          (only-in racket/function thunk)
-         (for-syntax syntax/parse
-                     racket/base)
+         (for-syntax racket/base)
          syntax/parse/define
          "private/util.rkt")
 

--- a/qi-test/tests/on.rkt
+++ b/qi-test/tests/on.rkt
@@ -6,8 +6,7 @@
          rackunit
          rackunit/text-ui
          (only-in math sqr)
-         (only-in adjutor values->list)
-         racket/function)
+         (only-in adjutor values->list))
 
 (define tests
   (test-suite

--- a/qi-test/tests/on.rkt
+++ b/qi-test/tests/on.rkt
@@ -21,7 +21,7 @@
                   (list 5 5)
                   "no clauses, binary")
     (check-equal? (on ()
-                    (const 3))
+                    (gen 3))
                   3
                   "no arguments"))
    (test-suite

--- a/qi-test/tests/qi.rkt
+++ b/qi-test/tests/qi.rkt
@@ -8,8 +8,7 @@
          (prefix-in threading: "threading.rkt")
          (prefix-in definitions: "definitions.rkt")
          (prefix-in macro: "macro.rkt")
-         (prefix-in util: "util.rkt")
-         "private/util.rkt")
+         (prefix-in util: "util.rkt"))
 
 (define tests
   (test-suite

--- a/qi-test/tests/threading.rkt
+++ b/qi-test/tests/threading.rkt
@@ -16,8 +16,8 @@
     "Edge/base cases"
     (check-equal? (values->list (~> ())) null)
     (check-equal? (values->list (~>> ())) null)
-    (check-equal? (~> () (const 5)) 5)
-    (check-equal? (~>> () (const 5)) 5)
+    (check-equal? (~> () (gen 5)) 5)
+    (check-equal? (~>> () (gen 5)) 5)
     (check-equal? (~> (4)) 4)
     (check-equal? (~>> (4)) 4)
     (check-equal? (values->list (~> (4 5 6))) '(4 5 6))

--- a/qi-test/tests/threading.rkt
+++ b/qi-test/tests/threading.rkt
@@ -6,8 +6,7 @@
          rackunit
          rackunit/text-ui
          (only-in math sqr)
-         (only-in adjutor values->list)
-         racket/function)
+         (only-in adjutor values->list))
 
 (define tests
   (test-suite

--- a/qi-test/tests/util.rkt
+++ b/qi-test/tests/util.rkt
@@ -15,10 +15,10 @@
     "report-syntax-error"
     (check-exn exn:fail:syntax?
                (thunk (report-syntax-error #'(dummy 1 2 3)
-                                           "blah: blah"
-                                           "Use it"
-                                           "like"
-                                           "this"))))))
+                        "blah: blah"
+                        "Use it"
+                        "like"
+                        "this"))))))
 
 (module+ main
   (void (run-tests tests)))


### PR DESCRIPTION
### Summary of Changes

A WIP branch to explore adding bindings to Qi. Specifically, an `as` form.

```
((☯ (~> (-< (~> list (as vs))
            +)
        (~a "The sum of " vs " is " _)))
 1 2)
;=> "The sum of (1 2) is 3"
```

Bindings could be useful in simple cases of eliminating incidental nonlinearity in the flow, and may also support cases where flow paths would otherwise "intersect" one another and so could not easily be done without bindings.

This is work towards #36 .

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
