### PR TITLE
Repo migration: update links to point to drym-org

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
 Contributing
 ============
 
-See the `Developer's Guide <https://github.com/countvajhula/qi/wiki/Developer%27s-Guide>`_.
+See the `Developer's Guide <https://github.com/drym-org/qi/wiki/Developer%27s-Guide>`_.

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,23 @@
-.. image:: https://github.com/countvajhula/qi/actions/workflows/test.yml/badge.svg
-    :target: https://github.com/countvajhula/qi/actions/workflows/test.yml
+.. image:: https://github.com/drym-org/qi/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/drym-org/qi/actions/workflows/test.yml
 
-.. image:: https://coveralls.io/repos/github/countvajhula/qi/badge.svg?branch=main
-    :target: https://coveralls.io/github/countvajhula/qi?branch=main
+.. image:: https://coveralls.io/repos/github/drym-org/qi/badge.svg?branch=main
+    :target: https://coveralls.io/github/drym-org/qi?branch=main
 
 .. image:: https://img.shields.io/badge/documentation-%E2%98%AF-blue
     :target: https://docs.racket-lang.org/qi/index.html
 
 .. image:: https://img.shields.io/badge/wiki-%E2%98%AF-yellowgreen
-    :target: https://github.com/countvajhula/qi/wiki
+    :target: https://github.com/drym-org/qi/wiki
 
 qi
 ===
 Another way to structure computations.
 
 Install it from the `Racket Package Index <https://pkgs.racket-lang.org/package/qi>`_.
-Read `the documentation <https://docs.racket-lang.org/qi/index.html>`_ to learn more. See `the Wiki <https://github.com/countvajhula/qi/wiki>`_ for community resources, events, and developer documentation.
+Read `the documentation <https://docs.racket-lang.org/qi/index.html>`_ to learn more. See `the Wiki <https://github.com/drym-org/qi/wiki>`_ for community resources, events, and developer documentation.
 
-In case the main documentation is unavailable, read the `backup docs <https://countvajhula.github.io/qi/>`_.
+In case the main documentation is unavailable, read the `backup docs <https://drym-org.github.io/qi/>`_.
 
 "License":
 ==========

--- a/qi-doc/scribblings/intro.scrbl
+++ b/qi-doc/scribblings/intro.scrbl
@@ -127,7 +127,7 @@ In the most common case where you are threading functions, Qi's threading form @
 
 For macros, we cannot use them naively as flows because macros expect all of their "arguments" to be provided syntactically at compile time -- meaning that the number of arguments must be known at compile time. This is not in general possible with Qi since flows may consume and produce an arbitrary number of values, and this number is only determined at runtime. Depending on what you are trying to do, however, there are many ways in which you still can @seclink["Converting_a_Macro_to_a_Flow"]{treat macros as flows in Qi} -- from simple escapes into Racket to more structured approaches including @seclink["Qi_Dialect_Interop"]{writing a Qi dialect}.
 
-The threading library also provides numerous shorthands for common cases, many of which don't have equivalents in Qi -- if you'd like to have these, please @hyperlink["https://github.com/countvajhula/qi/issues/"]{create an issue} on the source repo to register your interest.
+The threading library also provides numerous shorthands for common cases, many of which don't have equivalents in Qi -- if you'd like to have these, please @hyperlink["https://github.com/drym-org/qi/issues/"]{create an issue} on the source repo to register your interest.
 
 @close-eval[eval-for-docs]
 @(set! eval-for-docs #f)


### PR DESCRIPTION
### Summary of Changes

Update links in various files to point to drym-org instead of countvajhula.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
