### PR TITLE
Support more literal classes

### DIFF
--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -32,24 +32,22 @@
 
 (define-syntax-class subject
   #:attributes (args arity)
-  (pattern
-   (arg:expr ...)
-   #:with args #'(arg ...)
-   #:attr arity (length (syntax->list #'args))))
+  (pattern (arg:expr ...)
+    #:with args #'(arg ...)
+    #:attr arity (length (syntax->list #'args))))
 
 (define-syntax-class clause
-  (pattern
-   expr:expr))
+  (pattern expr:expr))
 
 (define-syntax-class vector-literal
-  (pattern
-   #(_ ...)))
+  (pattern #(_ ...)))
 
 (define-syntax-class box-literal
   (pattern #&v))
 
 (define-syntax-class (starts-with pfx)
-  (pattern
-   i:id #:when (string-prefix? (symbol->string
-                                (syntax-e #'i)) pfx)))
-
+  (pattern i:id
+    #:when (string-prefix?
+            (symbol->string
+             (syntax-e #'i))
+            pfx)))

--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -19,6 +19,7 @@
          expr:byte-regexp
          expr:vector-literal
          expr:box-literal
+         expr:prefab-literal
          ;; We'd like to treat quoted forms as literals as well. This
          ;; includes symbols, and would also include, for instance,
          ;; syntactic specifications of flows, since flows are
@@ -44,6 +45,10 @@
 
 (define-syntax-class box-literal
   (pattern #&v))
+
+(define-syntax-class prefab-literal
+  (pattern e:expr
+    #:when (prefab-struct-key (syntax-e #'e))))
 
 (define-syntax-class (starts-with pfx)
   (pattern i:id

--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -18,6 +18,7 @@
          expr:regexp
          expr:byte-regexp
          expr:vector-literal
+         expr:box-literal
          ;; We'd like to treat quoted forms as literals as well. This
          ;; includes symbols, and would also include, for instance,
          ;; syntactic specifications of flows, since flows are
@@ -43,6 +44,9 @@
 (define-syntax-class vector-literal
   (pattern
    #(_ ...)))
+
+(define-syntax-class box-literal
+  (pattern #&v))
 
 (define-syntax-class (starts-with pfx)
   (pattern

--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -17,6 +17,7 @@
          expr:number
          expr:regexp
          expr:byte-regexp
+         expr:vector-literal
          ;; We'd like to treat quoted forms as literals as well. This
          ;; includes symbols, and would also include, for instance,
          ;; syntactic specifications of flows, since flows are
@@ -38,6 +39,10 @@
 (define-syntax-class clause
   (pattern
    expr:expr))
+
+(define-syntax-class vector-literal
+  (pattern
+   #(_ ...)))
 
 (define-syntax-class (starts-with pfx)
   (pattern

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -49,6 +49,7 @@
      (check-equal? ((flow #(1 2 3)) 2) #(1 2 3) "literal vector")
      (check-equal? ((flow #&3) 2) #&3 "literal box")
      (check-equal? ((flow #&(1 2 3)) 2) #&(1 2 3) "literal collection in a box")
+     (check-equal? ((flow #s(dog "Fido")) 2) #s(dog "Fido") "literal prefab")
      (check-equal? ((flow '(+ 1 2)) 5) '(+ 1 2) "literal quoted list")
      (check-equal? ((flow `(+ 1 ,(* 2 3))) 5) '(+ 1 6) "literal quasiquoted list")
      (check-equal? (syntax->datum ((flow #'(+ 1 2)) 5)) '(+ 1 2) "Literal syntax quoted list"))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -47,6 +47,8 @@
      (check-equal? ((flow #rx"hi") 5) #rx"hi" "literal regexp")
      (check-equal? ((flow 'hi) 5) 'hi "literal symbol")
      (check-equal? ((flow #(1 2 3)) 2) #(1 2 3) "literal vector")
+     (check-equal? ((flow #&3) 2) #&3 "literal box")
+     (check-equal? ((flow #&(1 2 3)) 2) #&(1 2 3) "literal collection in a box")
      (check-equal? ((flow '(+ 1 2)) 5) '(+ 1 2) "literal quoted list")
      (check-equal? ((flow `(+ 1 ,(* 2 3))) 5) '(+ 1 6) "literal quasiquoted list")
      (check-equal? (syntax->datum ((flow #'(+ 1 2)) 5)) '(+ 1 2) "Literal syntax quoted list"))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -46,6 +46,7 @@
      (check-equal? ((flow #px"hi") 5) #px"hi" "literal regexp")
      (check-equal? ((flow #rx"hi") 5) #rx"hi" "literal regexp")
      (check-equal? ((flow 'hi) 5) 'hi "literal symbol")
+     (check-equal? ((flow #(1 2 3)) 2) #(1 2 3) "literal vector")
      (check-equal? ((flow '(+ 1 2)) 5) '(+ 1 2) "literal quoted list")
      (check-equal? ((flow `(+ 1 ,(* 2 3))) 5) '(+ 1 6) "literal quasiquoted list")
      (check-equal? (syntax->datum ((flow #'(+ 1 2)) 5)) '(+ 1 2) "Literal syntax quoted list"))


### PR DESCRIPTION
### Summary of Changes

This adds support for more literal classes: vectors, boxes and (maybe) prefabs.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
