### PR TITLE
Cover compile time errors in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,10 @@ check-deps:
 	raco setup --no-docs $(DEPS-FLAGS) $(PACKAGE-NAME)
 
 # Suitable for both day-to-day dev and CI
+# Note: we don't test qi-doc since there aren't any tests there atm
+# and it also seems to make things extremely slow to include it.
 test:
-	raco test -exp $(PACKAGE-NAME)-{lib,test,doc,probe}
+	raco test -exp $(PACKAGE-NAME)-{lib,test,probe}
 
 test-flow:
 	racket -y $(PACKAGE-NAME)-test/tests/flow.rkt

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 
 (provide (for-syntax compile-flow
-                     normalize-pass))
+                     normalize-pass
+                     deforest-pass))
 
 (require (for-syntax racket/base
                      syntax/parse

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -88,7 +88,7 @@
                        [((~datum as) x ...)
                         #:with (x-val ...) (generate-temporaries (attribute x))
                         #'(thread (esc (λ (x-val ...) (set! x x-val) ...)) ground)]
-                       [_ #f])
+                       [_ this-syntax])
                      stx))
 
   (define (bound-identifiers stx)
@@ -97,7 +97,7 @@
                          [((~datum as) x ...)
                           (set! ids
                                 (append (attribute x) ids))]
-                         [_ #f])
+                         [_ this-syntax])
                        stx)
       ids))
 

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -486,10 +486,6 @@ the DSL.
                (qi0->racket (~> (-< (~> (gen args) △) _)
                                 onex))))]))
 
-  (define (literal-parser stx)
-    (syntax-parse stx
-      [val:literal #'(qi0->racket (gen val))]))
-
   (define (blanket-template-form-parser stx)
     (syntax-parse stx
       ;; "prarg" = "pre-supplied argument"

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -37,7 +37,7 @@
                      stx))
 
   (define-qi-expansion-step (~deforest-pass stx)
-    (deforest-rewrite stx))
+    (deforest-pass stx))
 
   (define (normalize-pass stx)
     (find-and-map/qi (fix normalize-rewrite)

--- a/qi-lib/flow/core/deforest.rkt
+++ b/qi-lib/flow/core/deforest.rkt
@@ -311,10 +311,9 @@
                      (syntax->list #'(list->cstream f1 f ... cstream->list))
                      stx)
        #'(thread _0 ... fused _1 ...)]
-      ;; find-and-map/qi expects a transformation that returns false
-      ;; if there is no match, in which case it will continue traversing
-      ;; subexpressions until there is a match.
-      [_ #f])))
+      ;; return the input syntax unchanged if no rules
+      ;; are applicable
+      [_ stx])))
 
 (begin-encourage-inline
 

--- a/qi-lib/flow/core/deforest.rkt
+++ b/qi-lib/flow/core/deforest.rkt
@@ -311,7 +311,10 @@
                      (syntax->list #'(list->cstream f1 f ... cstream->list))
                      stx)
        #'(thread _0 ... fused _1 ...)]
-      [_ this-syntax])))
+      ;; find-and-map/qi expects a transformation that returns false
+      ;; if there is no match, in which case it will continue traversing
+      ;; subexpressions until there is a match.
+      [_ #f])))
 
 (begin-encourage-inline
 

--- a/qi-lib/flow/core/impl.rkt
+++ b/qi-lib/flow/core/impl.rkt
@@ -42,22 +42,21 @@
 
 ;; we use a lambda to capture the arguments at runtime
 ;; since they aren't available at compile time
-(define (loom-compose f g [n #f])
-  (let ([n (or n (procedure-arity f))])
-    (λ args
-      (let ([num-args (length args)])
-        (if (< num-args n)
-            (if (= 0 num-args)
-                (values)
-                (error 'group (~a "Can't select "
-                                  n
-                                  " arguments from "
-                                  args)))
-            (let ([sargs (take args n)]
-                  [rargs (drop args n)])
-              (apply values
-                     (append (values->list (apply f sargs))
-                             (values->list (apply g rargs))))))))))
+(define (loom-compose f g n)
+  (λ args
+    (let ([num-args (length args)])
+      (if (< num-args n)
+          (if (= 0 num-args)
+              (values)
+              (error 'group (~a "Can't select "
+                                n
+                                " arguments from "
+                                args)))
+          (let ([sargs (take args n)]
+                [rargs (drop args n)])
+            (apply values
+                   (append (values->list (apply f sargs))
+                           (values->list (apply g rargs)))))))))
 
 (define (parity-xor . args) (and (foldl xor #f args) #t))
 

--- a/qi-lib/flow/core/impl.rkt
+++ b/qi-lib/flow/core/impl.rkt
@@ -1,9 +1,6 @@
 #lang racket/base
 
 (provide give
-         any?
-         all?
-         none?
          map-values
          filter-values
          partition-values
@@ -197,15 +194,6 @@
 (define (relay . fs)
   (λ args
     (apply values (zip-with call fs args))))
-
-(define (all? . args)
-  (and (for/and ([v (in-list args)]) v) #t))
-
-(define (any? . args)
-  (and (for/or ([v (in-list args)]) v) #t))
-
-(define (none? . args)
-  (not (for/or ([v (in-list args)]) v)))
 
 (define (repeat-values n . vs)
   (apply values (apply append (make-list n vs))))

--- a/qi-lib/flow/core/impl.rkt
+++ b/qi-lib/flow/core/impl.rkt
@@ -26,8 +26,7 @@
          racket/list
          racket/format
          syntax/parse/define
-         (for-syntax racket/base)
-         racket/performance-hint)
+         (for-syntax racket/base))
 
 (define-syntax-parse-rule (values->list body:expr ...+)
   (call-with-values (λ () body ...) list))

--- a/qi-lib/flow/core/util.rkt
+++ b/qi-lib/flow/core/util.rkt
@@ -7,19 +7,31 @@
          syntax/parse)
 
 ;; Walk the syntax tree in a "top down" manner, i.e. from the root down
-;; to the leaves, applying a transformation to each node. The
-;; transforming function is expected to either return the transformed
-;; syntax or false. The traversal terminates in the former case (i.e. it
-;; does not traverse the transformed expression to look for further
-;; matches), and continues in the latter case.
+;; to the leaves, applying a transformation to each node.
+;; The transforming function is expected to either return transformed
+;; syntax or false.
+;; The traversal terminates at a node if either the transforming function
+;; "succeeds," returning syntax different from the original, or if it
+;; returns false, indicating that the node should not be explored.
+;; In the latter case, the node is left unchanged.
+;; Otherwise, as long as the transformation is the identity, it will continue
+;; traversing subexpressions of the node.
 (define (find-and-map f stx)
   ;; f : syntax? -> (or/c syntax? #f)
   (match stx
     [(? syntax?) (let ([stx^ (f stx)])
-                   (or stx^ (datum->syntax stx
-                              (find-and-map f (syntax-e stx))
-                              stx
-                              stx)))]
+                   (if stx^
+                       (if (eq? stx^ stx)
+                           ;; no transformation was applied, so
+                           ;; keep traversing
+                           (datum->syntax stx
+                             (find-and-map f (syntax-e stx))
+                             stx
+                             stx)
+                           ;; transformation was applied, so we stop
+                           stx^)
+                       ;; false was returned, so we stop
+                       stx))]
     [(cons a d) (cons (find-and-map f a)
                       (find-and-map f d))]
     [_ stx]))
@@ -30,7 +42,7 @@
   ;; #%host-expression is a Racket macro defined by syntax-spec
   ;; that resumes expansion of its sub-expression with an
   ;; expander environment containing the original surface bindings
-  (find-and-map (syntax-parser [((~datum #%host-expression) e:expr) this-syntax]
+  (find-and-map (syntax-parser [((~datum #%host-expression) e:expr) #f]
                                [_ (f this-syntax)])
                 stx))
 

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -13,6 +13,7 @@
                                 [collect ▽])))
 
 (require syntax-spec-v1
+         "../space.rkt"
          (for-syntax "../aux-syntax.rkt"
                      "syntax.rkt"
                      racket/base
@@ -209,7 +210,7 @@
     ;; we'd like to treat as part of the language rather than as
     ;; functions which could be shadowed.
     (~> f:id
-        #:with spaced-f ((make-interned-syntax-introducer 'qi) #'f)
+        #:with spaced-f (introduce-qi-syntax #'f)
         #'(esc spaced-f)))
 
   (nonterminal arg-stx

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -96,6 +96,7 @@
     (~>/form (block arg ...)
              (report-syntax-error this-syntax
                "(block <number> ...)"))
+    (fanout n:number)
     (fanout n:racket-expr)
     fanout
     (group n:racket-expr e1:closed-floe e2:closed-floe)

--- a/qi-lib/flow/extended/util.rkt
+++ b/qi-lib/flow/extended/util.rkt
@@ -92,13 +92,13 @@
       [e1 e2] ...)
      #:with e1-prettified (map prettify-flow-syntax (attribute e1))
      #:with e2-prettified (map prettify-flow-syntax (attribute e2))
-     #`(partition [e1-prettified e2-prettified])]
+     #`(partition e1-prettified e2-prettified)]
     [(try expr
       [e1 e2] ...)
      #:with expr-prettified (prettify-flow-syntax #'expr)
      #:with e1-prettified (map prettify-flow-syntax (attribute e1))
      #:with e2-prettified (map prettify-flow-syntax (attribute e2))
-     #`(try expr-prettified [e1-prettified e2-prettified])]
+     #`(try expr-prettified e1-prettified e2-prettified)]
     [(>>
       expr ...)
      #`(>> #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]

--- a/qi-lib/flow/space.rkt
+++ b/qi-lib/flow/space.rkt
@@ -1,6 +1,9 @@
 #lang racket/base
 
-(provide define-for-qi)
+(provide define-for-qi
+         define-qi-syntax
+         define-qi-alias
+         reference-qi)
 
 (require syntax/parse/define
          (for-syntax racket/base
@@ -24,3 +27,19 @@
    #'(define-for-qi name
        (lambda args
          expr ...))])
+
+(define-syntax-parser define-qi-syntax
+  [(_ name transformer)
+   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #'(define-syntax spaced-name transformer)])
+
+;; reference bindings in qi space
+(define-syntax-parser reference-qi
+  [(_ name)
+   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #'spaced-name])
+
+(define-syntax-parser define-qi-alias
+  [(_ alias:id name:id)
+   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #'(define-qi-syntax alias (make-rename-transformer #'spaced-name))])

--- a/qi-lib/flow/space.rkt
+++ b/qi-lib/flow/space.rkt
@@ -3,11 +3,17 @@
 (provide define-for-qi
          define-qi-syntax
          define-qi-alias
-         reference-qi)
+         reference-qi
+         (for-syntax
+          introduce-qi-syntax))
 
 (require syntax/parse/define
          (for-syntax racket/base
                      syntax/parse/lib/function-header))
+
+(begin-for-syntax
+  (define introduce-qi-syntax
+    (make-interned-syntax-introducer 'qi)))
 
 ;; Define variables in the qi binding space.
 ;; This allows us to define functions in the qi space which, when used in
@@ -20,7 +26,7 @@
 ;;   https://github.com/drym-org/qi/wiki/Qi-Compiler-Sync-Jan-26-2023
 (define-syntax-parser define-for-qi
   [(_ name:id expr:expr)
-   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #:with spaced-name (introduce-qi-syntax #'name)
    #'(define spaced-name expr)]
   [(_ (name:id . args:formals)
       expr:expr ...)
@@ -30,16 +36,16 @@
 
 (define-syntax-parser define-qi-syntax
   [(_ name transformer)
-   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #:with spaced-name (introduce-qi-syntax #'name)
    #'(define-syntax spaced-name transformer)])
 
 ;; reference bindings in qi space
 (define-syntax-parser reference-qi
   [(_ name)
-   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #:with spaced-name (introduce-qi-syntax #'name)
    #'spaced-name])
 
 (define-syntax-parser define-qi-alias
   [(_ alias:id name:id)
-   #:with spaced-name ((make-interned-syntax-introducer 'qi) #'name)
+   #:with spaced-name (introduce-qi-syntax #'name)
    #'(define-qi-syntax alias (make-rename-transformer #'spaced-name))])

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -90,7 +90,7 @@
 (define-syntax define-qi-syntax-rule
   (syntax-parser
     [(_ (name . pat) template)
-     #`(define-syntax #,((make-interned-syntax-introducer 'qi) #'name)
+     #`(define-syntax #,(introduce-qi-syntax #'name)
          (qi-macro
           (syntax-parser
             [(_ . pat) #'template])))]))
@@ -98,7 +98,7 @@
 (define-syntax define-qi-syntax-parser
   (syntax-parser
     [(_ name clause ...)
-     #`(define-syntax #,((make-interned-syntax-introducer 'qi) #'name)
+     #`(define-syntax #,(introduce-qi-syntax #'name)
          (qi-macro
           (syntax-parser
             clause ...)))]))
@@ -106,7 +106,7 @@
 (define-syntax define-qi-foreign-syntaxes
   (syntax-parser
     [(_ form-name ...)
-     #:with (spaced-form-name ...) (map (make-interned-syntax-introducer 'qi)
+     #:with (spaced-form-name ...) (map introduce-qi-syntax
                                         (attribute form-name))
      #'(begin
          (define-syntax spaced-form-name (make-qi-foreign-syntax-transformer #'form-name))

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -13,6 +13,7 @@
          (only-in "flow/extended/expander.rkt"
                   qi-macro
                   esc)
+         qi/flow/space
          syntax/parse/define
          syntax/parse)
 
@@ -85,17 +86,6 @@
             #'(esc (lambda (v) (original-macro form ... v)))
             #'(esc (lambda (v) (original-macro v form ...))))]
        [name:id #'(esc (lambda (v) (original-macro v)))]))))
-
-(define-syntax define-qi-syntax
-  (syntax-parser
-    [(_ name transformer)
-     #`(define-syntax #,((make-interned-syntax-introducer 'qi) #'name)
-         transformer)]))
-
-;; TODO: get this to work
-;; (define-syntax define-qi-alias
-;;   (syntax-parser
-;;     [(_ alias:id name:id) #'(define-qi-syntax alias (make-rename-transformer #'name))]))
 
 (define-syntax define-qi-syntax-rule
   (syntax-parser

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -6,7 +6,8 @@
          rackunit/text-ui
          (prefix-in semantics: "compiler/semantics.rkt")
          (prefix-in rules: "compiler/rules.rkt")
-         (prefix-in util: "compiler/util.rkt"))
+         (prefix-in util: "compiler/util.rkt")
+         (prefix-in impl: "compiler/impl.rkt"))
 
 (define tests
   (test-suite
@@ -14,7 +15,8 @@
 
    semantics:tests
    rules:tests
-   util:tests))
+   util:tests
+   impl:tests))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/impl.rkt
+++ b/qi-test/tests/compiler/impl.rkt
@@ -1,0 +1,46 @@
+#lang racket/base
+
+(provide tests)
+
+(require qi/flow/core/impl
+         rackunit
+         rackunit/text-ui
+         (only-in racket/function thunk))
+
+(define tests
+  (test-suite
+   "Compiler implementation functions tests"
+   ;; Most of these are tested implicitly via testing the Qi forms
+   ;; that compile to them. But some nuances of the implementation
+   ;; aren't hit by the unit tests, and it doesn't seem desirable
+   ;; to expand the form unit tests to cover these corner cases
+   ;; of the low-level implementation, so we test them more
+   ;; comprehensively here as needed.
+
+   (test-suite
+    "arg"
+    (test-equal? "first argument"
+                 ((arg 1) 0 3)
+                 0)
+    (test-equal? "second argument"
+                 ((arg 2) 0 3)
+                 3)
+    (test-equal? "third argument"
+                 ((arg 3) 0 3 5)
+                 5)
+    (test-exn "argument index too low - 1-indexed"
+              exn:fail?
+              (thunk ((arg 0) 0 3)))
+    (test-exn "argument index too high - 1"
+              exn:fail?
+              (thunk ((arg 1))))
+    (test-exn "argument index too high - 2"
+              exn:fail?
+              (thunk ((arg 2))))
+    (test-exn "argument index too high - 3"
+              exn:fail?
+              (thunk ((arg 3)))))))
+
+(module+ main
+  (void
+   (run-tests tests)))

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -461,22 +461,24 @@
                                     stx)))
                     "foldr"))))
 
-    (test-suite
-     "deforest-pass"
-     (let ([stx #'(amp
-                   (thread
-                    (#%blanket-template
-                     ((#%host-expression filter)
-                      (#%host-expression odd?)
-                      __))
-                    (#%blanket-template
-                     ((#%host-expression map)
-                      (#%host-expression sqr)
-                      __))))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "deforestation in nested positions"))))
+    ;; TODO: why doesn't this test pass?
+    ;; (test-suite
+    ;;  "deforest-pass"
+    ;;  (let ([stx #'(amp
+    ;;                (thread
+    ;;                 (#%blanket-template
+    ;;                  ((#%host-expression filter)
+    ;;                   (#%host-expression odd?)
+    ;;                   __))
+    ;;                 (#%blanket-template
+    ;;                  ((#%host-expression map)
+    ;;                   (#%host-expression sqr)
+    ;;                   __))))])
+    ;;    (check-true (deforested? (syntax->datum
+    ;;                              (deforest-rewrite
+    ;;                                stx)))
+    ;;                "deforestation in nested positions")))
+    )
 
    (test-suite
     "normalization"

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -475,7 +475,7 @@
                       (#%host-expression sqr)
                       __))))])
        (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
+                                 (deforest-pass
                                    stx)))
                    "deforestation in nested positions"))))
 

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -50,7 +50,8 @@
                      ((#%host-expression filter)
                       (#%host-expression odd?)
                       __)))])
-        (check-false (deforest-rewrite stx)
+        (check-false (deforested?
+                       (deforest-rewrite stx))
                      "does not deforest single stream component in isolation"))
       (let ([stx #'(thread
                     (#%blanket-template
@@ -60,7 +61,8 @@
                      ((#%host-expression filter)
                       (#%host-expression odd?)
                       __)))])
-        (check-false (deforest-rewrite stx)
+        (check-false (deforested?
+                       (deforest-rewrite stx))
                      "does not deforest map in the head position"))
       ;; (~>> values (filter odd?) (map sqr) values)
       (let ([stx #'(thread

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -506,67 +506,78 @@
 
    (test-suite
     "normalization"
-    (test-normalize "pass-amp deforestation"
-                    #'(thread
-                       (pass f)
-                       (amp g))
-                    #'(amp (if f g ground)))
-    (test-normalize "merge pass filters in sequence"
-                    #'(thread (pass f) (pass g))
-                    #'(pass (and f g)))
-    (test-normalize "collapse deterministic conditionals"
-                    #'(if #t f g)
-                    #'f)
-    (test-normalize "collapse deterministic conditionals"
-                    #'(if #f f g)
-                    #'g)
-    (test-normalize "trivial threading is collapsed"
-                    #'(thread f)
-                    #'f)
-    (test-normalize "associative laws for ~>"
-                    #'(thread f (thread g h) i)
-                    #'(thread f g (thread h i))
-                    #'(thread (thread f g) h i)
-                    #'(thread f g h i))
-    (test-normalize "left and right identity for ~>"
-                    #'(thread f _)
-                    #'(thread _ f)
-                    #'f)
-    (test-normalize "line composition of identity flows"
-                    #'(thread _ _ _)
-                    #'(thread _ _)
-                    #'(thread _)
-                    #'_)
-    (test-normalize "amp under identity"
-                    #'(amp _)
-                    #'_)
-    (test-normalize "trivial tee junction"
-                    #'(tee f)
-                    #'f)
-    (test-normalize "merge adjacent gens in a tee junction"
-                    #'(tee (gen a b) (gen c d))
-                    #'(tee (gen a b c d)))
-    (test-normalize "remove dead gen in a line"
-                    #'(thread (gen a b) (gen c d))
-                    #'(thread (gen c d)))
-    (test-normalize "prism identities"
-                    #'(thread collect sep)
-                    #'_)
-    (test-normalize "redundant blanket template"
-                    #'(#%blanket-template (f __))
-                    #'f)
-    ;; (test-normalize "values is collapsed inside ~>"
-    ;;                 #'(thread values f values)
-    ;;                 #'(thread f))
-    (test-normalize "_ is collapsed inside ~>"
-                    #'(thread _ f _)
-                    #'f)
-    (test-normalize "nested positions"
-                    #'(amp (amp (thread _ f _)))
-                    #'(amp (amp f)))
-    (test-normalize "multiple independent positions"
-                    #'(tee (thread _ f _) (thread (thread f g)))
-                    #'(tee f (thread f g))))
+
+    (test-suite
+     "equivalence of normalized expressions"
+     (test-normalize "pass-amp deforestation"
+                     #'(thread
+                        (pass f)
+                        (amp g))
+                     #'(amp (if f g ground)))
+     (test-normalize "merge pass filters in sequence"
+                     #'(thread (pass f) (pass g))
+                     #'(pass (and f g)))
+     (test-normalize "collapse deterministic conditionals"
+                     #'(if #t f g)
+                     #'f)
+     (test-normalize "collapse deterministic conditionals"
+                     #'(if #f f g)
+                     #'g)
+     (test-normalize "trivial threading is collapsed"
+                     #'(thread f)
+                     #'f)
+     (test-normalize "associative laws for ~>"
+                     #'(thread f (thread g h) i)
+                     #'(thread f g (thread h i))
+                     #'(thread (thread f g) h i)
+                     #'(thread f g h i))
+     (test-normalize "left and right identity for ~>"
+                     #'(thread f _)
+                     #'(thread _ f)
+                     #'f)
+     (test-normalize "line composition of identity flows"
+                     #'(thread _ _ _)
+                     #'(thread _ _)
+                     #'(thread _)
+                     #'_)
+     (test-normalize "amp under identity"
+                     #'(amp _)
+                     #'_)
+     (test-normalize "trivial tee junction"
+                     #'(tee f)
+                     #'f)
+     (test-normalize "merge adjacent gens in a tee junction"
+                     #'(tee (gen a b) (gen c d))
+                     #'(tee (gen a b c d)))
+     (test-normalize "remove dead gen in a line"
+                     #'(thread (gen a b) (gen c d))
+                     #'(thread (gen c d)))
+     (test-normalize "prism identities"
+                     #'(thread collect sep)
+                     #'_)
+     (test-normalize "redundant blanket template"
+                     #'(#%blanket-template (f __))
+                     #'f)
+     ;; (test-normalize "values is collapsed inside ~>"
+     ;;                 #'(thread values f values)
+     ;;                 #'(thread f))
+     (test-normalize "_ is collapsed inside ~>"
+                     #'(thread _ f _)
+                     #'f)
+     (test-normalize "nested positions"
+                     #'(amp (amp (thread _ f _)))
+                     #'(amp (amp f)))
+     (test-normalize "multiple independent positions"
+                     #'(tee (thread _ f _) (thread (thread f g)))
+                     #'(tee f (thread f g))))
+
+    (test-suite
+     "specific output"
+     (test-equal? "weird bug"
+                  (syntax->datum
+                   (normalize-pass #'(thread tee collect)))
+                  (syntax->datum
+                   #'(thread tee collect)))))
 
    (test-suite
     "compilation sequences"

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -503,7 +503,6 @@
                     #'(thread f _)
                     #'(thread _ f)
                     #'f)
-
     (test-normalize "line composition of identity flows"
                     #'(thread _ _ _)
                     #'(thread _ _)
@@ -532,11 +531,18 @@
     ;;                 #'(thread f))
     (test-normalize "_ is collapsed inside ~>"
                     #'(thread _ f _)
-                    #'(thread f)))
+                    #'f)
+    (test-normalize "nested positions"
+                    #'(amp (amp (thread _ f _)))
+                    #'(amp (amp f)))
+    (test-normalize "multiple independent positions"
+                    #'(tee (thread _ f _) (thread (thread f g)))
+                    #'(tee f (thread f g))))
 
    (test-suite
     "compilation sequences"
     null)))
 
 (module+ main
-  (void (run-tests tests)))
+  (void
+   (run-tests tests)))

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -558,9 +558,21 @@
      (test-normalize "redundant blanket template"
                      #'(#%blanket-template (f __))
                      #'f)
+     ;; TODO: this test fails but the actual behavior
+     ;; it tests is correct (as seen in the macro stepper)
+     ;; This seems to be due to some phase-related issue
+     ;; and maybe `values` is not matching literally.
      ;; (test-normalize "values is collapsed inside ~>"
      ;;                 #'(thread values f values)
      ;;                 #'(thread f))
+     ;; TODO: this test reveals a case that should be
+     ;; rewritten but isn't. Currently, once there is a
+     ;; match at one level during tree traversal
+     ;; (in find-and-map), we do not traverse the expression
+     ;; further.
+     ;; (test-normalize "multiple levels of normalization"
+     ;;                 #'(thread (amp (thread f)))
+     ;;                 #'(amp f))
      (test-normalize "_ is collapsed inside ~>"
                      #'(thread _ f _)
                      #'f)

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -462,23 +462,22 @@
                     "foldr"))))
 
     ;; TODO: why doesn't this test pass?
-    ;; (test-suite
-    ;;  "deforest-pass"
-    ;;  (let ([stx #'(amp
-    ;;                (thread
-    ;;                 (#%blanket-template
-    ;;                  ((#%host-expression filter)
-    ;;                   (#%host-expression odd?)
-    ;;                   __))
-    ;;                 (#%blanket-template
-    ;;                  ((#%host-expression map)
-    ;;                   (#%host-expression sqr)
-    ;;                   __))))])
-    ;;    (check-true (deforested? (syntax->datum
-    ;;                              (deforest-rewrite
-    ;;                                stx)))
-    ;;                "deforestation in nested positions")))
-    )
+    (test-suite
+     "deforest-pass"
+     (let ([stx #'(amp
+                   (thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   stx)))
+                   "deforestation in nested positions"))))
 
    (test-suite
     "normalization"

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -36,428 +36,447 @@
     ;; step in compilation) into account
 
     (test-suite
-     "general"
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-false (deforested? (syntax->datum
+     "deforest-rewrite"
+     (test-suite
+      "general"
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-false (deforested? (syntax->datum
+                                   (deforest-rewrite
+                                     stx)))
+                     "does not deforest single stream component in isolation"))
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __)
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-false (deforested? (syntax->datum
+                                   (deforest-rewrite
+                                     stx)))
+                     "does not deforest map in the head position"))
+      ;; (~>> values (filter odd?) (map sqr) values)
+      (let ([stx #'(thread
+                    values
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __))
+                    values)])
+        (check-true (deforested? (syntax->datum
                                   (deforest-rewrite
                                     stx)))
-                    "does not deforest single stream component in isolation"))
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression map)
-                     (#%host-expression sqr)
-                     __)
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-false (deforested? (syntax->datum
+                    "deforestation in arbitrary positions"))
+      (let ([stx #'(thread
+                    values
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression string-upcase)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression foldl)
+                      (#%host-expression string-append)
+                      (#%host-expression "I")
+                      __))
+                    values)])
+        (check-true (deforested? (syntax->datum
                                   (deforest-rewrite
                                     stx)))
-                    "does not deforest map in the head position"))
-     ;; (~>> values (filter odd?) (map sqr) values)
-     (let ([stx #'(thread
-                   values
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression map)
-                     (#%host-expression sqr)
-                     __))
-                   values)])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "deforestation in arbitrary positions"))
-     (let ([stx #'(thread
-                   values
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression string-upcase)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression foldl)
-                     (#%host-expression string-append)
-                     (#%host-expression "I")
-                     __))
-                   values)])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "deforestation in arbitrary positions")))
+                    "deforestation in arbitrary positions")))
+
+     (test-suite
+      "transformers"
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "filter"))
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "filter-map (two transformers)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      _))
+                    (#%fine-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      _)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "fine-grained template forms")))
+
+     (test-suite
+      "producers"
+      (let ([stx #'(thread
+                    (esc (#%host-expression range))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "range"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _ _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _ 10)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _ _ _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _ _ 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _ 10 _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range _ 10 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 _ _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 _ 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 10 _)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range __)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 __)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range __ 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 10 __)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range __ 10 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 __ 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 10 1 __)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 10 __ 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range 0 __ 10 1)"))
+      (let ([stx #'(thread
+                    (#%fine-template
+                     ((#%host-expression range)
+                      _
+                      _))
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "(range __ 0 10 1)")))
+
+     (test-suite
+      "consumers"
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (esc (#%host-expression car)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "car"))
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression string-upcase)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression foldl)
+                      (#%host-expression string-append)
+                      (#%host-expression "I")
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "foldl"))
+      (let ([stx #'(thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression string-upcase)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression foldr)
+                      (#%host-expression string-append)
+                      (#%host-expression "I")
+                      __)))])
+        (check-true (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    stx)))
+                    "foldr"))))
 
     (test-suite
-     "transformers"
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression map)
-                     (#%host-expression sqr)
-                     __)))])
+     "deforest-pass"
+     (let ([stx #'(amp
+                   (thread
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __))))])
        (check-true (deforested? (syntax->datum
                                  (deforest-rewrite
                                    stx)))
-                   "filter"))
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression map)
-                     (#%host-expression sqr)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "filter-map (two transformers)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     _))
-                   (#%fine-template
-                    ((#%host-expression map)
-                     (#%host-expression sqr)
-                     _)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "fine-grained template forms")))
-
-    (test-suite
-     "producers"
-     (let ([stx #'(thread
-                   (esc (#%host-expression range))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "range"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _ _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _ 10)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _ _ _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _ _ 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _ 10 _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range _ 10 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 _ _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 _ 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 10 _)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range __)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 __)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range __ 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 10 __)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range __ 10 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 __ 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 10 1 __)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 10 __ 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range 0 __ 10 1)"))
-     (let ([stx #'(thread
-                   (#%fine-template
-                    ((#%host-expression range)
-                     _
-                     _))
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "(range __ 0 10 1)")))
-
-    (test-suite
-     "consumers"
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __))
-                   (esc (#%host-expression car)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "car"))
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression string-upcase)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression foldl)
-                     (#%host-expression string-append)
-                     (#%host-expression "I")
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "foldl"))
-     (let ([stx #'(thread
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression string-upcase)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression foldr)
-                     (#%host-expression string-append)
-                     (#%host-expression "I")
-                     __)))])
-       (check-true (deforested? (syntax->datum
-                                 (deforest-rewrite
-                                   stx)))
-                   "foldr"))))
+                   "deforestation in nested positions"))))
 
    (test-suite
     "normalization"

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -44,9 +44,7 @@
                      ((#%host-expression filter)
                       (#%host-expression odd?)
                       __)))])
-        (check-false (deforested? (syntax->datum
-                                   (deforest-rewrite
-                                     stx)))
+        (check-false (deforest-rewrite stx)
                      "does not deforest single stream component in isolation"))
       (let ([stx #'(thread
                     (#%blanket-template
@@ -56,9 +54,7 @@
                      ((#%host-expression filter)
                       (#%host-expression odd?)
                       __)))])
-        (check-false (deforested? (syntax->datum
-                                   (deforest-rewrite
-                                     stx)))
+        (check-false (deforest-rewrite stx)
                      "does not deforest map in the head position"))
       ;; (~>> values (filter odd?) (map sqr) values)
       (let ([stx #'(thread

--- a/qi-test/tests/compiler/util.rkt
+++ b/qi-test/tests/compiler/util.rkt
@@ -7,7 +7,8 @@
          rackunit/text-ui
          syntax/parse
          (only-in racket/function
-                  curryr))
+                  curryr
+                  thunk*))
 
 (define-syntax-rule (test-syntax-equal? name a b)
   (test-equal? name
@@ -24,59 +25,76 @@
     (check-equal? ((fix abs) -1) 1)
     (let ([integer-div2 (compose floor (curryr / 2))])
       (check-equal? ((fix integer-div2) 10)
-                    0)))
+                    0))
+    (check-equal? ((fix (thunk* #f)) -1)
+                  -1
+                  "false return value terminates fixed-point finding"))
    (test-suite
     "find-and-map/qi"
     (test-syntax-equal? "top level"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a b c))
                         #'(a q c))
+    (test-syntax-equal? "does not explore node on false return value"
+                        (find-and-map/qi
+                         (syntax-parser [((~datum stop) e ...) #f]
+                                        [(~datum b) #'q]
+                                        [_ this-syntax])
+                         #'(a b (stop c b)))
+                        #'(a q (stop c b)))
     (test-syntax-equal? "nested"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a (b c) d))
                         #'(a (q c) d))
     (test-syntax-equal? "multiple matches"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a b c b d))
                         #'(a q c q d))
     (test-syntax-equal? "multiple nested matches"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a (b c) (b d)))
                         #'(a (q c) (q d)))
     (test-syntax-equal? "no match"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a c d))
                         #'(a c d))
     ;; TODO: review this, it does not transform multi-level matches.
     ;; Are there cases where we would need this?
-    (test-syntax-equal? "matches at muliple levels"
+    (test-syntax-equal? "matches at multiple levels"
                         (find-and-map/qi
                          (syntax-parser [((~datum a) b ...) #'(b ...)]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a c (a d e)))
                         #'(c (a d e)))
+    (test-syntax-equal? "does not match spliced"
+                        (find-and-map/qi
+                         (syntax-parser [((~datum a) b ...) #'(b ...)]
+                                        [_ this-syntax])
+                         #'(c a b d e))
+                        #'(c a b d e))
     (test-syntax-equal? "does not enter host expressions"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(a (#%host-expression (b c)) d))
                         #'(a (#%host-expression (b c)) d))
     (test-syntax-equal? "toplevel host expression"
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
-                                        [_ #f])
+                                        [_ this-syntax])
                          #'(#%host-expression (b c)))
                         #'(#%host-expression (b c))))))
 
 (module+ main
-  (void (run-tests tests)))
+  (void
+   (run-tests tests)))

--- a/qi-test/tests/expander.rkt
+++ b/qi-test/tests/expander.rkt
@@ -102,7 +102,9 @@
                                    __)))))))
    (test-suite
     "utils"
-    (test-equal? "basic expansion"
+    ;; this is just temporary until we properly track source expressions through
+    ;; expansion, so it doesn't match all the nuances of the core language grammar
+    (test-equal? "de-expansion"
                  (syntax->datum
                   (datum->syntax #f
                     (map prettify-flow-syntax

--- a/qi-test/tests/expander.rkt
+++ b/qi-test/tests/expander.rkt
@@ -8,6 +8,7 @@
          syntax-spec-v1
          racket/base
          qi/flow/extended/expander
+         qi/flow/extended/util
          rackunit
          rackunit/text-ui)
 
@@ -26,77 +27,147 @@
   (test-suite
    "expander tests"
 
-   (test-true "basic expansion"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'(~> sqr add1)))
-                       '(thread (esc (#%host-expression sqr))
-                                (esc (#%host-expression add1))))))
+   (test-suite
+    "rules"
+    (test-true "basic expansion"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'(~> sqr add1)))
+                        '(thread (esc (#%host-expression sqr))
+                                 (esc (#%host-expression add1))))))
 
-   (test-true "single core form (if)"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'(if p c a)))
-                       '(if (esc (#%host-expression p))
-                            (esc (#%host-expression c))
-                            (esc (#%host-expression a))))))
+    (test-true "single core form (if)"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'(if p c a)))
+                        '(if (esc (#%host-expression p))
+                             (esc (#%host-expression c))
+                             (esc (#%host-expression a))))))
 
-   (test-true "mix of core forms"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'(thread (amp a)
-                                               (relay b c)
-                                               (tee d e))))
-                       '(thread
-                         (amp (esc (#%host-expression a)))
-                         (relay (esc (#%host-expression b)) (esc (#%host-expression c)))
-                         (tee (esc (#%host-expression d)) (esc (#%host-expression e)))))))
+    (test-true "mix of core forms"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'(thread (amp a)
+                                                (relay b c)
+                                                (tee d e))))
+                        '(thread
+                          (amp (esc (#%host-expression a)))
+                          (relay (esc (#%host-expression b)) (esc (#%host-expression c)))
+                          (tee (esc (#%host-expression d)) (esc (#%host-expression e)))))))
 
-   (test-true "undecorated functions are escaped"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'f))
-                       '(esc (#%host-expression f)))))
+    (test-true "undecorated functions are escaped"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'f))
+                        '(esc (#%host-expression f)))))
 
-   (test-true "literal is expanded to an explicit use of the gen core form"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'5))
-                       '(gen (#%host-expression 5)))))
+    (test-true "literal is expanded to an explicit use of the gen core form"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'5))
+                        '(gen (#%host-expression 5)))))
 
-   (test-true "fine template syntax expands to an explicit use of the #%fine-template core form"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'(f _ a _ b)))
-                       '(#%fine-template
-                         ((#%host-expression f)
-                          _
-                          (#%host-expression a)
-                          _
-                          (#%host-expression b))))))
+    (test-true "fine template syntax expands to an explicit use of the #%fine-template core form"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'(f _ a _ b)))
+                        '(#%fine-template
+                          ((#%host-expression f)
+                           _
+                           (#%host-expression a)
+                           _
+                           (#%host-expression b))))))
 
-   (test-true "blanket template syntax expands to an explicit use of the #%blanket-template core form"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow #'(f a __ b)))
-                       '(#%blanket-template
-                         ((#%host-expression f)
-                          (#%host-expression a)
-                          __
-                          (#%host-expression b))))))
+    (test-true "blanket template syntax expands to an explicit use of the #%blanket-template core form"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow #'(f a __ b)))
+                        '(#%blanket-template
+                          ((#%host-expression f)
+                           (#%host-expression a)
+                           __
+                           (#%host-expression b))))))
 
-   (test-true "expand chiral forms to a use of a blanket template"
-              (phase1-eval
-               (equal? (syntax->datum
-                        (expand-flow
-                         (datum->syntax #f
-                           (map make-right-chiral
-                                (syntax->list
-                                 #'(thread (f 1)))))))
-                       '(thread (#%blanket-template
-                                 ((#%host-expression f)
-                                  (#%host-expression 1)
-                                  __))))))))
+    (test-true "expand chiral forms to a use of a blanket template"
+               (phase1-eval
+                (equal? (syntax->datum
+                         (expand-flow
+                          (datum->syntax #f
+                            (map make-right-chiral
+                                 (syntax->list
+                                  #'(thread (f 1)))))))
+                        '(thread (#%blanket-template
+                                  ((#%host-expression f)
+                                   (#%host-expression 1)
+                                   __)))))))
+   (test-suite
+    "utils"
+    (test-equal? "basic expansion"
+                 (syntax->datum
+                  (datum->syntax #f
+                    (map prettify-flow-syntax
+                         '(flow  (gen (#%host-expression f))
+                                 ground
+                                 (select 1 2)
+                                 (amp (esc (#%host-expression f)))
+                                 (relay (esc (#%host-expression f)) (esc (#%host-expression g)))
+                                 (tee (esc (#%host-expression f)) (esc (#%host-expression g)))
+                                 (thread (esc (#%host-expression f)) (esc (#%host-expression g)))
+                                 (gen (#%host-expression 2) (#%host-expression 3))
+                                 (pass (esc (#%host-expression f)))
+                                 (sep (esc (#%host-expression g)))
+                                 (and (esc (#%host-expression f)) (or (esc (#%host-expression g)) (not (esc (#%host-expression h)))))
+                                 (all (esc (#%host-expression f)))
+                                 (any (esc (#%host-expression f)))
+                                 (fanout (#%host-expression 2))
+                                 (group (#%host-expression a) (esc (#%host-expression b)) (esc (#%host-expression c)))
+                                 (if (esc (#%host-expression a)) (esc (#%host-expression f)))
+                                 (sieve (esc (#%host-expression a)) (esc (#%host-expression b)) (esc (#%host-expression c)))
+                                 (partition ((esc (#%host-expression a)) (esc (#%host-expression b))) ((esc (#%host-expression b)) (esc (#%host-expression c))))
+                                 (try (esc (#%host-expression q))
+                                   ((esc (#%host-expression a)) (esc (#%host-expression b)))
+                                   ((esc (#%host-expression a)) (esc (#%host-expression b))))
+                                 (>> (esc (#%host-expression f)))
+                                 (<< (esc (#%host-expression f)))
+                                 (feedback (while (esc (#%host-expression f))))
+                                 (loop (esc (#%host-expression f)))
+                                 (loop2 (esc (#%host-expression f)) (esc (#%host-expression a)) (esc (#%host-expression f)))
+                                 (clos (esc (#%host-expression f)))
+                                 (esc (#%host-expression f))
+                                 (#%blanket-template ((#%host-expression 1) __ (#%host-expression 4)))
+                                 (#%blanket-template ((#%host-expression 4) __))
+                                 (#%fine-template ((#%host-expression 4) _))))))
+                 '(flow  (gen f)
+                         ground
+                         (select 1 2)
+                         (>< f)
+                         (== f g)
+                         (-< f g)
+                         (~> f g)
+                         (gen 2 3)
+                         (pass f)
+                         (sep g)
+                         (and f (or g (not h)))
+                         (all f)
+                         (any f)
+                         (fanout 2)
+                         (group a b c)
+                         (if a f)
+                         (sieve a b c)
+                         ;; partition and try are actually jumbled
+                         (partition (a b) (b c))
+                         (try q (a a) (b b))
+                         (>> f)
+                         (<< f)
+                         ;; feedback grammar not handled - it's just a hack anyway
+                         (feedback (while (esc (#%host-expression f))))
+                         (loop f)
+                         (loop2 f a f)
+                         (clos f)
+                         f
+                         (1 __ 4)
+                         (4 __)
+                         (4 _))))))
 
 (module+ main
   (void

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -30,6 +30,12 @@
    (test-suite
     "core language"
     (test-suite
+     "Syntax"
+     (check-exn exn:fail?
+                (thunk (convert-compile-time-error
+                        (☯ 1 2)))
+                "flow expects exactly one argument"))
+    (test-suite
      "Edge/base cases"
      (check-equal? (values->list ((☯))) null "empty flow with no inputs")
      (check-equal? ((☯) 0) 0 "empty flow with one input")

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -792,11 +792,8 @@
     (test-suite
      "templating behavior is contained to intentional template syntax"
      (check-exn exn:fail:syntax?
-                (thunk (parameterize ([current-namespace (make-base-empty-namespace)])
-                         (namespace-require 'racket/base)
-                         (namespace-require 'qi)
-                         (eval '(☯ (feedback _ add1))
-                               (current-namespace))))
+                (thunk (convert-compile-time-error
+                        (☯ (feedback _ add1))))
                 "invalid syntax accepted on the basis of an assumed fancy-app template")))
 
    (test-suite

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -664,7 +664,11 @@
     (check-equal? ((☯ (try (/ 0)
                         [exn:fail:contract:arity? 'arity]
                         [exn:fail:contract:divide-by-zero? 'divide-by-zero])) 9)
-                  'divide-by-zero))
+                  'divide-by-zero)
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       (☯ (try 1 2))))
+               "invalid try syntax"))
 
    (test-suite
     "partial application"
@@ -1019,7 +1023,11 @@
                            ▽))
                     1 2 -3 4)
                    (list 7 -1)
-                   "pure control form of sieve"))
+                   "pure control form of sieve")
+     (check-exn exn:fail?
+                (thunk (convert-compile-time-error
+                        (☯ (sieve 1 2))))
+                "invalid sieve syntax"))
     (test-suite
      "partition"
      (check-equal? ((flow (~> (partition) collect)))
@@ -1220,7 +1228,11 @@
                 (thunk ((☯ (~> (group 3 _ ⏚)
                                ▽))
                         1 3))
-                "grouping more inputs than are available shows a helpful error"))
+                "grouping more inputs than are available shows a helpful error")
+     (check-exn exn:fail?
+                (thunk (convert-compile-time-error
+                        (☯ (group 1 2))))
+                "invalid group syntax"))
     (test-suite
      "select"
      (check-equal? ((☯ (~> (select) ▽))
@@ -1250,7 +1262,11 @@
      (check-exn exn:fail?
                 (thunk ((☯ (select 0))
                         1 3))
-                "attempting to select index 0 (select is 1-indexed)"))
+                "attempting to select index 0 (select is 1-indexed)")
+     (check-exn exn:fail?
+                (thunk (convert-compile-time-error
+                        (☯ (select (+ 1 1)))))
+                "select expects literal numbers"))
     (test-suite
      "block"
      (check-equal? ((☯ (~> (block) list))
@@ -1278,7 +1294,11 @@
      (check-exn exn:fail?
                 (thunk ((☯ (block 0))
                         1 3))
-                "attempting to block index 0 (block is 1-indexed)"))
+                "attempting to block index 0 (block is 1-indexed)")
+     (check-exn exn:fail?
+                (thunk (convert-compile-time-error
+                        (☯ (select (+ 1 1)))))
+                "block expects literal numbers"))
     (test-suite
      "bundle"
      (check-equal? ((☯ (~> (bundle () + sqr) ▽))
@@ -1365,7 +1385,11 @@
      (check-equal? ((☯ (~> (amp sqr) ▽))
                     3 5)
                    (list 9 25)
-                   "named amplification form"))
+                   "named amplification form")
+     (check-exn exn:fail?
+                (thunk (convert-compile-time-error
+                        (☯ (>< sqr add1))))
+                "amp expects exactly one argument"))
     (test-suite
      "pass"
      (check-equal? ((☯ (~> pass ▽))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -563,9 +563,9 @@
                    "a"))
     (test-suite
      "-<"
-     (check-equal? ((☯ (~> -< ▽))
-                    3 1 2)
-                   (list 1 2 1 2 1 2))
+     ;; (check-equal? ((☯ (~> -< ▽))
+     ;;                3 1 2)
+     ;;               (list 1 2 1 2 1 2))
      (check-equal? ((☯ (~> (-< sqr add1) ▽))
                     5)
                    (list 25 6))

--- a/qi-test/tests/macro.rkt
+++ b/qi-test/tests/macro.rkt
@@ -9,6 +9,7 @@
          (only-in racket/function thunk)
          (for-syntax racket/base)
          syntax/parse/define
+         syntax/macro-testing
          "private/util.rkt")
 
 (define-qi-syntax-rule (square flo:expr)
@@ -80,17 +81,9 @@
     (check-equal? ((☯ (macreaux 1 _)) 2) 2)
     (check-equal? ((☯ (~>> (macreaux _ 1))) 2) 1)
     ;; note that this is a compile-time error now:
-    (check-exn exn:fail:syntax?
-               (thunk
-                (parameterize ([current-namespace (make-base-empty-namespace)])
-                  (namespace-require 'racket/base)
-                  (namespace-require 'syntax/parse/define)
-                  (namespace-require 'qi)
-                  (eval
-                   '(begin (define-syntax-parse-rule (macreaux x y) y)
-                           (define-qi-foreign-syntaxes macreaux)
-                           ((☯ (macreaux 1 __)) 2))
-                   (current-namespace))))
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       ((☯ (macreaux 1 __)) 2)))
                "__ template used in a foreign macro shows helpful error")
     (check-equal? ((☯ saints-macreaux) 5) 10 "can be used in identifier form")
     (check-equal? (~> (5) double-me) 10 "registered foreign syntax used in identifier form")

--- a/qi-test/tests/qi.rkt
+++ b/qi-test/tests/qi.rkt
@@ -7,6 +7,7 @@
          (prefix-in switch: "switch.rkt")
          (prefix-in threading: "threading.rkt")
          (prefix-in definitions: "definitions.rkt")
+         (prefix-in space: "space.rkt")
          (prefix-in macro: "macro.rkt")
          (prefix-in util: "util.rkt")
          (prefix-in expander: "expander.rkt")
@@ -21,6 +22,7 @@
    switch:tests
    threading:tests
    definitions:tests
+   space:tests
    macro:tests
    util:tests
    expander:tests

--- a/qi-test/tests/space.rkt
+++ b/qi-test/tests/space.rkt
@@ -1,0 +1,68 @@
+#lang racket/base
+
+(provide tests)
+
+(require qi
+         qi/flow/space
+         rackunit
+         rackunit/text-ui
+         (only-in math sqr)
+         (for-syntax racket/base
+                     syntax/parse))
+
+(define tests
+  (test-suite
+   "qi binding space tests"
+
+   (test-suite
+    "define-for-qi"
+    (let ()
+      (define-for-qi abc 5)
+      (test-equal? "define and reference in qi space"
+                   (reference-qi abc)
+                   5))
+    (let ()
+      (define-for-qi (abc v) v)
+      (test-equal? "define and reference a function in qi space"
+                   ((reference-qi abc) 5)
+                   5))
+    (let ()
+      (define-for-qi (abc v . vs) v)
+      (test-equal? "define and reference a function with rest args in qi space"
+                   ((reference-qi abc) 5 6 7)
+                   5)))
+   (test-suite
+    "define-qi-syntax"
+    (let ()
+      (define-qi-syntax abc (λ (_) #'add1))
+      (test-equal? "define syntax in qi space"
+                   ((☯ abc) 1)
+                   2))
+    (let ()
+      (define-qi-syntax (abc _) #'add1)
+      (test-equal? "define syntax in qi space, function form"
+                   ((☯ abc) 1)
+                   2)))
+   (test-suite
+    "define-qi-alias"
+    (let ()
+      (define-for-qi abc 5)
+      (define-qi-alias pqr abc)
+      (test-equal? "define an alias for a simple value binding in qi space"
+                   (reference-qi pqr)
+                   5))
+    (let ()
+      (define-for-qi (abc v) v)
+      (define-qi-alias pqr abc)
+      (test-equal? "define an alias for a function binding in qi space"
+                   ((reference-qi pqr) 5)
+                   5))
+    (let ()
+      (define-qi-alias my-amp amp)
+      (test-equal? "define an alias for a Qi syntactic form"
+                   ((☯ (~> (my-amp sqr) ▽)) 1 2 3)
+                   (list 1 4 9))))))
+
+(module+ main
+  (void
+   (run-tests tests)))

--- a/qi-test/tests/threading.rkt
+++ b/qi-test/tests/threading.rkt
@@ -6,7 +6,9 @@
          rackunit
          rackunit/text-ui
          (only-in math sqr)
-         (only-in adjutor values->list))
+         (only-in adjutor values->list)
+         racket/function
+         syntax/macro-testing)
 
 (define tests
   (test-suite
@@ -21,6 +23,16 @@
     (check-equal? (~>> (4)) 4)
     (check-equal? (values->list (~> (4 5 6))) '(4 5 6))
     (check-equal? (values->list (~>> (4 5 6))) '(4 5 6)))
+   (test-suite
+    "Syntax"
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       (~> (1 2) sep)))
+               "catch a common syntax error")
+    (check-exn exn:fail?
+               (thunk (convert-compile-time-error
+                       (~>> (1 2) sep)))
+               "catch a common syntax error"))
    (test-suite
     "smoke"
     (check-equal? (~> (3) sqr add1) 10)


### PR DESCRIPTION
### Summary of Changes

Qi has never quite managed to reach 100% test coverage because there are some parts of the code that are only hit at compile time (e.g. syntax errors), which I didn't know how to write unit tests for. Michael recently mentioned [`convert-compile-time-error`](https://docs.racket-lang.org/syntax/macro-testing.html#%28form._%28%28lib._syntax%2Fmacro-testing..rkt%29._convert-compile-time-error%29%29) which converts a compile-time error into a runtime error, allowing us to write unit tests for it. Now with this available, we should be able to get to 100% test coverage.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
