### PR TITLE
use new syntax-spec racket-expr feature

### DIFF
--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -72,8 +72,7 @@
     #:description "a flow expression"
     #:binding-space qi
 
-    (gen e:expr ...)
-    #:binding (host e)
+    (gen e:racket-expr ...)
     ;; Ad hoc expansion rule to allow _ to be used in application
     ;; position in a template.
     ;; Without it, (_ v ...) would be treated as an error since
@@ -111,8 +110,7 @@
     (~>/form (block arg ...)
              (report-syntax-error this-syntax
                "(block <number> ...)"))
-    (group n:expr e1:floe e2:floe)
-    #:binding (host n)
+    (group n:racket-expr e1:floe e2:floe)
     group
     (~>/form (group arg ...)
              (report-syntax-error this-syntax
@@ -148,15 +146,12 @@
               ((~datum then) thenex:floe))
     (feedback ((~datum while) tilex:floe) onex:floe)
     (feedback ((~datum while) tilex:floe))
-    (feedback n:expr
+    (feedback n:racket-expr
               ((~datum then) thenex:floe)
               onex:floe)
-    #:binding (host n)
-    (feedback n:expr
+    (feedback n:racket-expr
               ((~datum then) thenex:floe))
-    #:binding (host n)
-    (feedback n:expr onex:floe)
-    #:binding (host n)
+    (feedback n:racket-expr onex:floe)
     (feedback onex:floe)
     feedback
     (loop pred:floe mapex:floe combex:floe retex:floe)
@@ -169,8 +164,7 @@
     (~> (~literal apply) #'appleye)
     clos
     (clos onex:floe)
-    (esc ex:expr)
-    #:binding (host ex)
+    (esc ex:racket-expr)
 
     ;; backwards compat macro extensibility via Racket macros
     (~> ((~var ext-form (starts-with "qi:")) expr ...)
@@ -209,5 +203,4 @@
     (~datum __)
     k:keyword
 
-    e:expr
-    #:binding (host e)))
+    e:racket-expr))


### PR DESCRIPTION
### Summary of Changes

Per Sid's suggestion I added a feature to syntax-spec to avoid the need to specify binding rules with `host`. Instead, Racket subexpressions are represented via the built-in `racket-expr` nonterminal.

### Public Domain Dedication

- [X] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
