### PR TITLE
docs: disambiguate Usage sections

### DIFF
--- a/qi-doc/scribblings/intro.scrbl
+++ b/qi-doc/scribblings/intro.scrbl
@@ -37,7 +37,7 @@ Qi is a hosted language on the @hyperlink["https://racket-lang.org/"]{Racket pla
 
  Qi is designed to be used in tandem with a host language, such as Racket itself. To use it in a Racket module, simply @racket[(require qi)].
 
-@section{Usage}
+@section{Using Qi}
 
  Qi may be used in normal (e.g. Racket) code by employing an appropriate @seclink["Language_Interface"]{interface} form. These forms embed the Qi language into the host language, that is, they allow you to use Qi anywhere in your program, and provide shorthands for common cases.
 

--- a/qi-doc/scribblings/tutorial.scrbl
+++ b/qi-doc/scribblings/tutorial.scrbl
@@ -65,7 +65,7 @@ And then, downloading the tutorial is as simple as:
 
 D. Ben Knoble's @seclink["top" #:indirect? #t #:doc '(lib "tmux-vim-demo/scribblings/tmux-vim-demo.scrbl")]{tmux-vim-demo} allows you to run expressions on demand with a split-pane view of your Vim buffer and a tmux session containing a Racket REPL. See @hyperlink["https://github.com/countvajhula/qi-tutorial"]{the README} for additional setup instructions once the package is installed. Once set up, you can simply use @code{r} (in Normal mode) to send the current line or visual selection to the REPL.
 
-@subsection{Usage}
+@subsection{Starting the Tutorial}
 
 Open the file @code{start.rkt} in your favorite editor.
 

--- a/qi-doc/scribblings/using-qi.scrbl
+++ b/qi-doc/scribblings/using-qi.scrbl
@@ -8,7 +8,7 @@
 
 @title{When Should I Use Qi?}
 
-Okay, so you've read @secref["Usage"] and understand at a high level that there are interface macros providing a bridge between Racket and Qi, which allow you to use Qi anywhere in your code, and you have some idea of how to write flows (maybe you've gone through the @secref["Tutorial"]). Let's now look at a collection of examples that may help shed light on when you should use Qi vs Racket or another language.
+Okay, so you've read @secref{Using Qi} and understand at a high level that there are interface macros providing a bridge between Racket and Qi, which allow you to use Qi anywhere in your code, and you have some idea of how to write flows (maybe you've gone through the @secref["Tutorial"]). Let's now look at a collection of examples that may help shed light on when you should use Qi vs Racket or another language.
 
 @table-of-contents[]
 


### PR DESCRIPTION
### Summary of Changes

This helps prevent the following class of warnings:

```
2023-01-25T16:03:22.1514470Z WARNING: collected information for key multiple times: '(index-entry (part "Usage")); values: (list '("Usage") (list (element #f '("Usage"))) (part-index-desc)) (list '("Usage") (list (element #f '("Usage"))) (part-index-desc))
2023-01-25T16:03:22.1516528Z WARNING: collected information for key multiple times: '(part "Usage"); values: (vector '("Usage") '(part "Usage") '(3 2) (list (mobile-root #<path:/home/runner/.local/share/racket/8.7/pkgs/qi-doc/doc/qi>) #"Introduction_and_Usage.html") #f) (vector '("Usage") '(part "Usage") '(3 1 3) (list (mobile-root #<path:/home/runner/.local/share/racket/8.7/pkgs/qi-doc/doc/qi>) #"Tutorial.html") #f)
```

In particular, it also helps clarify what `@secref{Usage}` should actually refer to: the Tutorial Usage or the Introduction Usage? I've assumed the latter in adjusting the reference there.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
