### PR TITLE
fixup! docs: disambiguate Usage sections

### DIFF
--- a/qi-doc/scribblings/using-qi.scrbl
+++ b/qi-doc/scribblings/using-qi.scrbl
@@ -8,7 +8,7 @@
 
 @title{When Should I Use Qi?}
 
-Okay, so you've read @secref{Using Qi} and understand at a high level that there are interface macros providing a bridge between Racket and Qi, which allow you to use Qi anywhere in your code, and you have some idea of how to write flows (maybe you've gone through the @secref["Tutorial"]). Let's now look at a collection of examples that may help shed light on when you should use Qi vs Racket or another language.
+Okay, so you've read @secref{Using_Qi} and understand at a high level that there are interface macros providing a bridge between Racket and Qi, which allow you to use Qi anywhere in your code, and you have some idea of how to write flows (maybe you've gone through the @secref["Tutorial"]). Let's now look at a collection of examples that may help shed light on when you should use Qi vs Racket or another language.
 
 @table-of-contents[]
 


### PR DESCRIPTION
I forgot secref's convert spaces to underscores…

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
