### PR TITLE
Benchmarks and tests

### DIFF
--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -16,7 +16,8 @@
          racket/undefined
          (prefix-in fancy: fancy-app)
          racket/list
-         "deforest.rkt")
+         "deforest.rkt"
+         "normalize.rkt")
 
 (begin-for-syntax
 
@@ -41,63 +42,6 @@
   ;; syntax whose expansion compiles the code
   (define (compile-flow stx)
     (process-bindings (optimize-flow stx)))
-
-  (define (normalize-rewrite stx)
-    ;; TODO: the "active" components of the expansions should be
-    ;; optimized, i.e. they should be wrapped with a recursive
-    ;; call to the optimizer
-    ;; TODO: eliminate outdated rules here
-    (syntax-parse stx
-      ;; "deforestation" for values
-      ;; (~> (pass f) (>< g)) → (>< (if f g ⏚))
-      [((~datum thread) _0 ... ((~datum pass) f) ((~datum amp) g) _1 ...)
-       #'(thread _0 ... (amp (if f g ground)) _1 ...)]
-      ;; merge amps in sequence
-      [((~datum thread) _0 ... ((~datum amp) f) ((~datum amp) g) _1 ...)
-       #`(thread _0 ... #,(normalize-rewrite #'(amp (thread f g))) _1 ...)]
-      ;; merge pass filters in sequence
-      [((~datum thread) _0 ... ((~datum pass) f) ((~datum pass) g) _1 ...)
-       #'(thread _0 ... (pass (and f g)) _1 ...)]
-      ;; collapse deterministic conditionals
-      [((~datum if) (~datum #t) f g) #'f]
-      [((~datum if) (~datum #f) f g) #'g]
-      ;; trivial threading form
-      [((~datum thread) f)
-       #'f]
-      ;; associative laws for ~>
-      [((~datum thread) _0 ... ((~datum thread) f ...) _1 ...) ; note: greedy matching
-       #'(thread _0 ... f ... _1 ...)]
-      ;; left and right identity for ~>
-      [((~datum thread) _0 ... (~datum _) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      ;; composition of identity flows is the identity flow
-      [((~datum thread) (~datum _) ...)
-       #'_]
-      ;; identity flows composed using a relay
-      [((~datum relay) (~datum _) ...)
-       #'_]
-      ;; amp and identity
-      [((~datum amp) (~datum _))
-       #'_]
-      ;; trivial tee junction
-      [((~datum tee) f)
-       #'f]
-      ;; merge adjacent gens
-      [((~datum tee) _0 ... ((~datum gen) a ...) ((~datum gen) b ...) _1 ...)
-       #'(tee _0 ... (gen a ... b ...) _1 ...)]
-      ;; prism identities
-      ;; Note: (~> ... △ ▽ ...) can't be rewritten to `values` since that's
-      ;; only valid if the input is in fact a list, and is an error otherwise,
-      ;; and we can only know this at runtime.
-      [((~datum thread) _0 ... (~datum collect) (~datum sep) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      ;; collapse `values` and `_` inside a threading form
-      [((~datum thread) _0 ... (~literal values) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      [((~datum thread) _0 ... (~datum _) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      ;; return syntax unchanged if there are no applicable normalizations
-      [_ stx]))
 
   ;; Applies f repeatedly to the init-val terminating the loop if the
   ;; result of f is #f or the new syntax object is eq? to the previous

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -1,9 +1,7 @@
 #lang racket/base
 
 (provide (for-syntax compile-flow
-                     ;; TODO: only used in unit tests, maybe try
-                     ;; using a submodule to avoid providing these usually
-                     deforest-rewrite))
+                     normalize-pass))
 
 (require (for-syntax racket/base
                      syntax/parse
@@ -28,6 +26,11 @@
       (emit-local-step stx0 stx1 #:id #'name)
       stx1))
 
+  ;; TODO: move this to a common utils module for use in all
+  ;; modules implementing optimization passes
+  ;; Also, resolve
+  ;;   "syntax-local-expand-observer: not currently expanding"
+  ;; issue encountered in running compiler unit tests
   (define-syntax-rule (define-qi-expansion-step (name stx0)
                         body ...)
     (define (name stx0)
@@ -39,7 +42,7 @@
   (define (compile-flow stx)
     (process-bindings (optimize-flow stx)))
 
-  (define-qi-expansion-step (normalize-rewrite stx)
+  (define (normalize-rewrite stx)
     ;; TODO: the "active" components of the expansions should be
     ;; optimized, i.e. they should be wrapped with a recursive
     ;; call to the optimizer

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -88,7 +88,12 @@
       ;; and we can only know this at runtime.
       [((~datum thread) _0 ... (~datum collect) (~datum sep) _1 ...)
        #'(thread _0 ... _1 ...)]
-      ;; return syntax unchanged if there are no known optimizations
+      ;; collapse `values` and `_` inside a threading form
+      [((~datum thread) _0 ... (~literal values) _1 ...)
+       #'(thread _0 ... _1 ...)]
+      [((~datum thread) _0 ... (~datum _) _1 ...)
+       #'(thread _0 ... _1 ...)]
+      ;; return syntax unchanged if there are no applicable normalizations
       [_ stx]))
 
   ;; Applies f repeatedly to the init-val terminating the loop if the

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -45,9 +45,6 @@
     ;; call to the optimizer
     ;; TODO: eliminate outdated rules here
     (syntax-parse stx
-      ;; restorative optimization for "all"
-      [((~datum thread) ((~datum amp) onex) (~datum AND))
-       #`(esc (give (curry andmap #,(compile-flow #'onex))))]
       ;; "deforestation" for values
       ;; (~> (pass f) (>< g)) → (>< (if f g ⏚))
       [((~datum thread) _0 ... ((~datum pass) f) ((~datum amp) g) _1 ...)

--- a/qi-lib/flow/core/normalize.rkt
+++ b/qi-lib/flow/core/normalize.rkt
@@ -9,9 +9,6 @@
 
   ;; 0. "Qi-normal form"
   (define (normalize-rewrite stx)
-    ;; TODO: the "active" components of the expansions should be
-    ;; optimized, i.e. they should be wrapped with a recursive
-    ;; call to the optimizer
     ;; TODO: eliminate outdated rules here
     (syntax-parse stx
       ;; "deforestation" for values

--- a/qi-lib/flow/core/normalize.rkt
+++ b/qi-lib/flow/core/normalize.rkt
@@ -1,0 +1,66 @@
+#lang racket/base
+
+(provide (for-syntax normalize-rewrite))
+
+(require (for-syntax racket/base
+                     syntax/parse))
+
+(begin-for-syntax
+
+  ;; 0. "Qi-normal form"
+  (define (normalize-rewrite stx)
+    ;; TODO: the "active" components of the expansions should be
+    ;; optimized, i.e. they should be wrapped with a recursive
+    ;; call to the optimizer
+    ;; TODO: eliminate outdated rules here
+    (syntax-parse stx
+      ;; "deforestation" for values
+      ;; (~> (pass f) (>< g)) → (>< (if f g ⏚))
+      [((~datum thread) _0 ... ((~datum pass) f) ((~datum amp) g) _1 ...)
+       #'(thread _0 ... (amp (if f g ground)) _1 ...)]
+      ;; merge amps in sequence
+      [((~datum thread) _0 ... ((~datum amp) f) ((~datum amp) g) _1 ...)
+       #`(thread _0 ... #,(normalize-rewrite #'(amp (thread f g))) _1 ...)]
+      ;; merge pass filters in sequence
+      [((~datum thread) _0 ... ((~datum pass) f) ((~datum pass) g) _1 ...)
+       #'(thread _0 ... (pass (and f g)) _1 ...)]
+      ;; collapse deterministic conditionals
+      [((~datum if) (~datum #t) f g) #'f]
+      [((~datum if) (~datum #f) f g) #'g]
+      ;; trivial threading form
+      [((~datum thread) f)
+       #'f]
+      ;; associative laws for ~>
+      [((~datum thread) _0 ... ((~datum thread) f ...) _1 ...) ; note: greedy matching
+       #'(thread _0 ... f ... _1 ...)]
+      ;; left and right identity for ~>
+      [((~datum thread) _0 ... (~datum _) _1 ...)
+       #'(thread _0 ... _1 ...)]
+      ;; composition of identity flows is the identity flow
+      [((~datum thread) (~datum _) ...)
+       #'_]
+      ;; identity flows composed using a relay
+      [((~datum relay) (~datum _) ...)
+       #'_]
+      ;; amp and identity
+      [((~datum amp) (~datum _))
+       #'_]
+      ;; trivial tee junction
+      [((~datum tee) f)
+       #'f]
+      ;; merge adjacent gens
+      [((~datum tee) _0 ... ((~datum gen) a ...) ((~datum gen) b ...) _1 ...)
+       #'(tee _0 ... (gen a ... b ...) _1 ...)]
+      ;; prism identities
+      ;; Note: (~> ... △ ▽ ...) can't be rewritten to `values` since that's
+      ;; only valid if the input is in fact a list, and is an error otherwise,
+      ;; and we can only know this at runtime.
+      [((~datum thread) _0 ... (~datum collect) (~datum sep) _1 ...)
+       #'(thread _0 ... _1 ...)]
+      ;; collapse `values` and `_` inside a threading form
+      [((~datum thread) _0 ... (~literal values) _1 ...)
+       #'(thread _0 ... _1 ...)]
+      [((~datum thread) _0 ... (~datum _) _1 ...)
+       #'(thread _0 ... _1 ...)]
+      ;; return syntax unchanged if there are no applicable normalizations
+      [_ stx])))

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -82,6 +82,9 @@
        car))
 
 (define-flow range-map-sum
+  ;; TODO: this should be written as (apply +)
+  ;; and that should be normalized to (foldr/l + 0)
+  ;; (depending on which of foldl/foldr is more performant)
   (~>> (range 0) (map sqr) (foldr + 0)))
 
 (define-flow long-functional-pipeline

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -16,6 +16,7 @@
          filter-map
          filter-map-foldr
          filter-map-foldl
+         long-functional-pipeline
          filter-map-values
          range-map-sum
          double-list
@@ -87,12 +88,14 @@
   (~>> (range 0)
        (map sqr)))
 
-;; (define-flow filter-map
-;;   (~>> (filter odd?)
-;;        (map sqr)
-;;        identity
-;;        (filter (λ (v) (< v 10)))
-;;        (map sqr)))
+(define-flow long-functional-pipeline
+  (~>> (range 0)
+       (filter odd?)
+       (map sqr)
+       values
+       (filter (λ (v) (< (remainder v 10) 5)))
+       (map (λ (v) (* 2 v)))
+       (foldl + 0)))
 
 (define-flow range-map-sum
   (~>> (range 0) (map sqr) (foldr + 0)))

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -1,10 +1,5 @@
 #lang racket/base
 
-(require racket/match
-         racket/function)
-
-(require racket/performance-hint)
-
 (provide conditionals
          composition
          root-mean-square
@@ -66,9 +61,6 @@
 
 ;; (define-flow filter-map
 ;;   (~> △ (>< (if odd? sqr ⏚)) ▽))
-
-;; (define-flow filter-map
-;;   (~>> (filter odd?) (map sqr)))
 
 (define-flow filter-map
   (~>> (filter odd?)

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -12,6 +12,7 @@
          pingala
          eratosthenes
          collatz
+         range-map
          filter-map
          filter-map-foldr
          filter-map-foldl
@@ -82,6 +83,10 @@
   (~>> (filter odd?)
        (map sqr)
        (foldl + 0)))
+
+(define-flow range-map
+  (~>> (range 0)
+       (map sqr)))
 
 ;; (define-flow filter-map
 ;;   (~>> (filter odd?)

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -7,7 +7,7 @@
          pingala
          eratosthenes
          collatz
-         range-map
+         range-map-car
          filter-map
          filter-map-foldr
          filter-map-foldl
@@ -76,9 +76,13 @@
        (map sqr)
        (foldl + 0)))
 
-(define-flow range-map
+(define-flow range-map-car
   (~>> (range 0)
-       (map sqr)))
+       (map sqr)
+       car))
+
+(define-flow range-map-sum
+  (~>> (range 0) (map sqr) (foldr + 0)))
 
 (define-flow long-functional-pipeline
   (~>> (range 0)
@@ -88,9 +92,6 @@
        (filter (λ (v) (< (remainder v 10) 5)))
        (map (λ (v) (* 2 v)))
        (foldl + 0)))
-
-(define-flow range-map-sum
-  (~>> (range 0) (map sqr) (foldr + 0)))
 
 ;; (define filter-double
 ;;   (map (☯ (when odd?

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -94,11 +94,8 @@
 ;;        (filter (λ (v) (< v 10)))
 ;;        (map sqr)))
 
-(define (~sum vs)
-  (apply + vs))
-
 (define-flow range-map-sum
-  (~>> (range 1) (map sqr) ~sum))
+  (~>> (range 0) (map sqr) (foldr + 0)))
 
 ;; (define filter-double
 ;;   (map (☯ (when odd?

--- a/qi-sdk/profile/nonlocal/qi/main.rkt
+++ b/qi-sdk/profile/nonlocal/qi/main.rkt
@@ -70,9 +70,8 @@
 ;;   (~>> (filter odd?) (map sqr)))
 
 (define-flow filter-map
-  (~>> values
-       (~>> (filter odd?)
-            (map sqr))))
+  (~>> (filter odd?)
+       (map sqr)))
 
 (define-flow filter-map-foldr
   (~>> (filter odd?)

--- a/qi-sdk/profile/nonlocal/racket/main.rkt
+++ b/qi-sdk/profile/nonlocal/racket/main.rkt
@@ -75,11 +75,8 @@
   (apply values
          (map sqr (filter odd? vs))))
 
-(define (~sum vs)
-  (apply + vs))
-
 (define (range-map-sum n)
-  (~sum (map sqr (range 1 n))))
+  (apply + (map sqr (range 0 n))))
 
 (define (double-list lst)
   (apply append (map (λ (v) (list v v)) lst)))

--- a/qi-sdk/profile/nonlocal/racket/main.rkt
+++ b/qi-sdk/profile/nonlocal/racket/main.rkt
@@ -7,7 +7,7 @@
          pingala
          eratosthenes
          collatz
-         range-map
+         range-map-car
          filter-map
          filter-map-foldr
          filter-map-foldl
@@ -60,9 +60,6 @@
         [(odd? n) (cons n (collatz (+ (* 3 n) 1)))]
         [(even? n) (cons n (collatz (quotient n 2)))]))
 
-(define (range-map v)
-  (map sqr (range 0 v)))
-
 (define (filter-map lst)
   (map sqr (filter odd? lst)))
 
@@ -71,6 +68,12 @@
 
 (define (filter-map-foldl lst)
   (foldl + 0 (map sqr (filter odd? lst))))
+
+(define (range-map-car v)
+  (car (map sqr (range 0 v))))
+
+(define (range-map-sum n)
+  (apply + (map sqr (range 0 n))))
 
 (define (long-functional-pipeline v)
   (foldl +
@@ -85,9 +88,6 @@
 (define (filter-map-values . vs)
   (apply values
          (map sqr (filter odd? vs))))
-
-(define (range-map-sum n)
-  (apply + (map sqr (range 0 n))))
 
 (define (double-list lst)
   (apply append (map (λ (v) (list v v)) lst)))

--- a/qi-sdk/profile/nonlocal/racket/main.rkt
+++ b/qi-sdk/profile/nonlocal/racket/main.rkt
@@ -11,6 +11,7 @@
          filter-map
          filter-map-foldr
          filter-map-foldl
+         long-functional-pipeline
          filter-map-values
          range-map-sum
          double-list
@@ -70,6 +71,16 @@
 
 (define (filter-map-foldl lst)
   (foldl + 0 (map sqr (filter odd? lst))))
+
+(define (long-functional-pipeline v)
+  (foldl +
+         0
+         (map (λ (v) (* 2 v))
+              (filter (λ (v) (< (remainder v 10) 5))
+                      (values
+                       (map sqr
+                            (filter odd?
+                                    (range 0 v))))))))
 
 (define (filter-map-values . vs)
   (apply values

--- a/qi-sdk/profile/nonlocal/racket/main.rkt
+++ b/qi-sdk/profile/nonlocal/racket/main.rkt
@@ -7,6 +7,7 @@
          pingala
          eratosthenes
          collatz
+         range-map
          filter-map
          filter-map-foldr
          filter-map-foldl
@@ -57,6 +58,9 @@
   (cond [(<= n 1) (list n)]
         [(odd? n) (cons n (collatz (+ (* 3 n) 1)))]
         [(even? n) (cons n (collatz (quotient n 2)))]))
+
+(define (range-map v)
+  (map sqr (range 0 v)))
 
 (define (filter-map lst)
   (map sqr (filter odd? lst)))

--- a/qi-sdk/profile/nonlocal/spec.rkt
+++ b/qi-sdk/profile/nonlocal/spec.rkt
@@ -20,7 +20,7 @@
         (bm "root-mean-square"
             check-list
             500000)
-        (bm "range-map"
+        (bm "range-map-car"
             check-value-large
             50000)
         (bm "filter-map"

--- a/qi-sdk/profile/nonlocal/spec.rkt
+++ b/qi-sdk/profile/nonlocal/spec.rkt
@@ -21,8 +21,8 @@
             check-list
             500000)
         (bm "range-map"
-            check-value
-            500000)
+            check-value-large
+            50000)
         (bm "filter-map"
             check-list
             500000)

--- a/qi-sdk/profile/nonlocal/spec.rkt
+++ b/qi-sdk/profile/nonlocal/spec.rkt
@@ -20,6 +20,9 @@
         (bm "root-mean-square"
             check-list
             500000)
+        (bm "range-map"
+            check-value
+            500000)
         (bm "filter-map"
             check-list
             500000)

--- a/qi-sdk/profile/nonlocal/spec.rkt
+++ b/qi-sdk/profile/nonlocal/spec.rkt
@@ -35,6 +35,9 @@
         (bm "filter-map-foldl"
             check-large-list
             50000)
+        (bm "long-functional-pipeline"
+            check-value-large
+            5000)
         (bm "range-map-sum"
             check-value-large
             5000)

--- a/qi-sdk/profile/util.rkt
+++ b/qi-sdk/profile/util.rkt
@@ -5,6 +5,7 @@
          check-value
          check-value-medium-large
          check-value-large
+         check-value-very-large
          check-list
          check-large-list
          check-values
@@ -62,6 +63,8 @@
 (define check-value-medium-large (curryr check-value #(100 200 300)))
 
 (define check-value-large (curryr check-value #(1000)))
+
+(define check-value-very-large (curryr check-value #(100000)))
 
 ;; This uses the same list input each time. Not sure if that
 ;; may end up being cached at some level and thus obfuscate

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -20,6 +20,7 @@
                 #'(#%partial-application
                    ((#%host-expression filter)
                     (#%host-expression odd?))))])
+      ;; note this tests the rule in isolation; with normalization this would never be necessary
       (check-equal? (syntax->datum
                      (deforest-rewrite
                        #`(thread #,stx)))
@@ -27,19 +28,17 @@
                       (esc
                        (λ (lst)
                          ((cstream->list (inline-compose1 (filter-cstream-next odd?) list->cstream-next)) lst))))
-                    "deforestation of map -- note this tests the rule in isolation; with normalization this would never be necessary"))
+                    "deforest filter"))
     (let ([stx (make-right-chiral
                 #'(#%partial-application
                    ((#%host-expression map)
                     (#%host-expression sqr))))])
+      ;; note this tests the rule in isolation; with normalization this would never be necessary
       (check-equal? (syntax->datum
                      (deforest-rewrite
                        #`(thread #,stx)))
-                    '(thread
-                      (esc
-                       (λ (lst)
-                         ((cstream->list (inline-compose1 (map-cstream-next sqr) list->cstream-next)) lst))))
-                    "deforestation of filter -- note this tests the rule in isolation; with normalization this would never be necessary"))
+                    '(thread (#%partial-application ((#%host-expression map) (#%host-expression sqr))))
+                    "does not deforest map in the head position"))
     (let ([stx (map make-right-chiral
                     (syntax->list
                      #'(values
@@ -70,7 +69,7 @@
     (let ([stx (map make-right-chiral
                     (syntax->list
                      #'((#%partial-application
-                         ((#%host-expression map)
+                         ((#%host-expression filter)
                           (#%host-expression string-upcase)))
                         (#%partial-application
                          ((#%host-expression foldl)
@@ -86,7 +85,7 @@
                            string-append
                            "I"
                            (inline-compose1
-                            (map-cstream-next
+                            (filter-cstream-next
                              string-upcase)
                             list->cstream-next))
                           lst))))

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -68,6 +68,34 @@
                     "deforestation in arbitrary positions"))
     (let ([stx (map make-right-chiral
                     (syntax->list
+                     #`(values
+                        #,(cons 'thread (map make-right-chiral
+                                             (syntax->list
+                                              #'((#%partial-application
+                                                  ((#%host-expression filter)
+                                                   (#%host-expression odd?)))
+                                                 (#%partial-application
+                                                  ((#%host-expression map)
+                                                   (#%host-expression sqr))))))))))])
+      (check-equal? (syntax->datum
+                     (deforest-rewrite
+                       #`(thread #,@stx)))
+                    '(thread
+                      values
+                      (esc
+                       (λ (lst)
+                         ((cstream->list
+                           (inline-compose1
+                            (map-cstream-next
+                             sqr)
+                            (filter-cstream-next
+                             odd?)
+                            list->cstream-next))
+                          lst)))
+                      values)
+                    "deforestation in nested positions"))
+    (let ([stx (map make-right-chiral
+                    (syntax->list
                      #'((#%partial-application
                          ((#%host-expression filter)
                           (#%host-expression string-upcase)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -1546,7 +1546,10 @@
                    "ABCI")
      (check-equal? ((☯ (~>> (map string-upcase) (foldl string-append "I")))
                     (list "a" "b" "c"))
-                   "CBAI")))))
+                   "CBAI")
+     (check-equal? ((☯ (~>> (range 10) (map sqr) car))
+                    0)
+                   0)))))
 
 (module+ main
   (void (run-tests tests)))


### PR DESCRIPTION
### Summary of Changes

- A benchmark for `range-map-car` to compare against `range-map-sum`
- fix failing compiler tests
- add more compiler tests, including introducing f(a) = f(b) style tests for normalization (see [Best practices for testing compiler optimizations](https://racket.discourse.group/t/best-practices-for-testing-compiler-optimizations/2369))
- couple more normalization rules / cleanup
- move normalization pass into its own module

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
