### PR TITLE
Reduce chirality to templates

### DIFF
--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -255,23 +255,6 @@
     [((~datum #%fine-template) (prarg-pre ... (~datum _) prarg-post ...))
      #'(fancy:#%app prarg-pre ... _ prarg-post ...)]
 
-    ;; Pre-supplied arguments without a template
-    [((~datum #%partial-application) (natex prarg ...+))
-     ;; we use currying instead of templates when a template hasn't
-     ;; explicitly been indicated since in such cases, we cannot
-     ;; always infer the appropriate arity for a template (e.g. it
-     ;; may change under composition within the form), while a
-     ;; curried function will accept any number of arguments
-     #:do [(define chirality (syntax-property this-syntax 'chirality))]
-     (if (and chirality (eq? chirality 'right))
-         #'(lambda args
-             (apply natex prarg ... args))
-         ;; TODO: keyword arguments don't work for the left-chiral case
-         ;; since we can't just blanket place the pre-supplied args
-         ;; and need to handle the keyword arguments differently
-         ;; from the positional arguments.
-         #'(lambda args
-             ((kw-helper natex args) prarg ...)))]
     ;; if in the course of optimization we ever end up with a fully
     ;; simplified host expression, the compiler would a priori reject it as
     ;; not being a core Qi expression. So we add this extra rule here
@@ -557,7 +540,9 @@ the DSL.
                         prarg-post ...)
                 prarg-pre ...)]
       [((~datum #%blanket-template) (natex prarg-pre ...+ (~datum __)))
-       #'(curry natex prarg-pre ...)]
+       #'(lambda args
+           (apply natex prarg-pre ... args))]
       [((~datum #%blanket-template)
         (natex (~datum __) prarg-post ...+))
-       #'(curryr natex prarg-post ...)])))
+       #'(lambda args
+           ((kw-helper natex args) prarg-post ...))])))

--- a/qi-lib/flow/core/deforest.rkt
+++ b/qi-lib/flow/core/deforest.rkt
@@ -34,11 +34,11 @@
   ;; no syntax class producer is matched.
   (define-syntax-class fusable-stream-producer
     #:attributes (next prepare contract name curry)
-    #:datum-literals (#%host-expression #%partial-application esc)
+    #:datum-literals (#%host-expression #%blanket-template esc)
     ;; Explicit range producers. We have to conver all four variants
     ;; as they all come with different runtime contracts!
     (pattern (~and (~or (esc (#%host-expression (~literal range)))
-                        (#%partial-application
+                        (#%blanket-template
                          ((#%host-expression (~literal range))
                           (~seq (~between (#%host-expression arg) 1 3) ...))))
                    stx)
@@ -72,57 +72,47 @@
   ;; `map` cannot be in this class.
   (define-syntax-class fusable-stream-transformer0
     #:attributes (f next)
-    #:datum-literals (#%host-expression #%partial-application)
-    (pattern (~and (#%partial-application
-                    ((#%host-expression (~literal filter))
-                     (#%host-expression f)))
-                   stx)
-             #:do [(define chirality (syntax-property #'stx 'chirality))]
-             #:when (and chirality (eq? chirality 'right))
-             #:attr next #'filter-cstream-next))
+    #:datum-literals (#%host-expression #%blanket-template __)
+    (pattern (#%blanket-template
+              ((#%host-expression (~literal filter))
+               (#%host-expression f)
+               __))
+      #:attr next #'filter-cstream-next))
 
   ;; All implemented stream transformers - within the stream, only
   ;; single value is being passed and therefore procedures like `map`
   ;; can (and should) be matched.
   (define-syntax-class fusable-stream-transformer
     #:attributes (f next)
-    #:datum-literals (#%host-expression #%partial-application)
-    (pattern (~and (#%partial-application
-                    ((#%host-expression (~literal map))
-                     (#%host-expression f)))
-                   stx)
-             #:do [(define chirality (syntax-property #'stx 'chirality))]
-             #:when (and chirality (eq? chirality 'right))
-             #:attr next #'map-cstream-next)
-    (pattern (~and (#%partial-application
-                    ((#%host-expression (~literal filter))
-                     (#%host-expression f)))
-                   stx)
-             #:do [(define chirality (syntax-property #'stx 'chirality))]
-             #:when (and chirality (eq? chirality 'right))
-             #:attr next #'filter-cstream-next))
+    #:datum-literals (#%host-expression #%blanket-template __)
+    (pattern (#%blanket-template
+              ((#%host-expression (~literal map))
+               (#%host-expression f)
+               __))
+      #:attr next #'map-cstream-next)
+    (pattern (#%blanket-template
+              ((#%host-expression (~literal filter))
+               (#%host-expression f)
+               __))
+      #:attr next #'filter-cstream-next))
 
   ;; Terminates the fused sequence (consumes the stream) and produces
   ;; an actual result value.
   (define-syntax-class fusable-stream-consumer
     #:attributes (end)
-    #:datum-literals (#%host-expression #%partial-application)
-    (pattern (~and (#%partial-application
-                    ((#%host-expression (~literal foldr))
-                     (#%host-expression op)
-                     (#%host-expression init)))
-                   stx)
-             #:do [(define chirality (syntax-property #'stx 'chirality))]
-             #:when (and chirality (eq? chirality 'right))
-             #:attr end #'(foldr-cstream-next op init))
-    (pattern (~and (#%partial-application
-                    ((#%host-expression (~literal foldl))
-                     (#%host-expression op)
-                     (#%host-expression init)))
-                   stx)
-             #:do [(define chirality (syntax-property #'stx 'chirality))]
-             #:when (and chirality (eq? chirality 'right))
-             #:attr end #'(foldl-cstream-next op init))
+    #:datum-literals (#%host-expression #%blanket-template __)
+    (pattern (#%blanket-template
+              ((#%host-expression (~literal foldr))
+               (#%host-expression op)
+               (#%host-expression init)
+               __))
+      #:attr end #'(foldr-cstream-next op init))
+    (pattern (#%blanket-template
+              ((#%host-expression (~literal foldl))
+               (#%host-expression op)
+               (#%host-expression init)
+               __))
+      #:attr end #'(foldl-cstream-next op init))
     (pattern (~literal cstream->list)
              #:attr end #'(cstream-next->list))
     (pattern (esc (#%host-expression (~literal car)))

--- a/qi-lib/flow/extended/forms.rkt
+++ b/qi-lib/flow/extended/forms.rkt
@@ -10,7 +10,6 @@
                                 [effect ε])))
 
 (require (for-syntax racket/base
-                     (only-in racket/list make-list)
                      "syntax.rkt"
                      "../aux-syntax.rkt")
          syntax/parse/define

--- a/qi-lib/flow/extended/syntax.rkt
+++ b/qi-lib/flow/extended/syntax.rkt
@@ -31,6 +31,12 @@
    onex:clause
    #:with parsed #'onex))
 
+(define-syntax-class pre-supplied-argument
+  (pattern
+   (~not
+    (~or (~datum _)
+         (~datum __)))))
+
 (define (make-right-chiral stx)
   (syntax-property stx 'chirality 'right))
 
@@ -55,7 +61,7 @@
 (define-syntax-class partial-application-form
   ;; "prarg" = "pre-supplied argument"
   (pattern
-   (natex prarg ...+)))
+   (natex prarg:pre-supplied-argument ...+)))
 
 (define-syntax-class any-stx
   (pattern _))

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -75,7 +75,31 @@
       (check-true (deforested? (syntax->datum
                                 (deforest-rewrite
                                   #`(thread #,@stx))))
-                  "deforestation in arbitrary positions")))
+                  "deforestation in arbitrary positions"))
+    (let ([stx (syntax->list #'((#%fine-template
+                                 ((#%host-expression filter)
+                                  (#%host-expression odd?)
+                                  _))
+                                (#%fine-template
+                                 ((#%host-expression map)
+                                  (#%host-expression sqr)
+                                  _))))])
+      (check-true (deforested? (syntax->datum
+                                (deforest-rewrite
+                                  #`(thread #,@stx))))
+                  "deforest fine-grained template forms"))
+    (let ([stx (syntax->list #'((#%blanket-template
+                                 ((#%host-expression filter)
+                                  (#%host-expression odd?)
+                                  __))
+                                (#%blanket-template
+                                 ((#%host-expression map)
+                                  (#%host-expression sqr)
+                                  __))))])
+      (check-true (deforested? (syntax->datum
+                                (deforest-rewrite
+                                  #`(thread #,@stx))))
+                  "deforest blanket template forms")))
    (test-suite
     "normalization"
     (test-normalize #'(thread

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -28,50 +28,53 @@
 
    (test-suite
     "deforestation"
-    (let ([stx (map make-right-chiral
-                    (syntax->list #'((#%partial-application
-                                      ((#%host-expression filter)
-                                       (#%host-expression odd?)))
-                                     (#%partial-application
-                                      ((#%host-expression map)
-                                       (#%host-expression sqr))))))])
+    (let ([stx (syntax->list #'((#%blanket-template
+                                 ((#%host-expression filter)
+                                  (#%host-expression odd?)
+                                  __))
+                                (#%blanket-template
+                                 ((#%host-expression map)
+                                  (#%host-expression sqr)
+                                  __))))])
       (check-true (deforested? (syntax->datum
                                 (deforest-rewrite
                                   #`(thread #,@stx))))
                   "deforest filter"))
-    (let ([stx (make-right-chiral
-                #'(#%partial-application
-                   ((#%host-expression map)
-                    (#%host-expression sqr))))])
+    (let ([stx #'(#%blanket-template
+                  ((#%host-expression map)
+                   (#%host-expression sqr)
+                   __))])
       ;; note this tests the rule in isolation; with normalization this would never be necessary
       (check-false (deforested? (syntax->datum
                                  (deforest-rewrite
                                    #`(thread #,stx))))
                    "does not deforest map in the head position"))
     ;; (~>> values (filter odd?) (map sqr) values)
-    (let ([stx (map make-right-chiral
-                    (syntax->list
-                     #'(values
-                        (#%partial-application
-                         ((#%host-expression filter)
-                          (#%host-expression odd?)))
-                        (#%partial-application
-                         ((#%host-expression map)
-                          (#%host-expression sqr)))
-                        values)))])
+    (let ([stx (syntax->list
+                #'(values
+                   (#%blanket-template
+                    ((#%host-expression filter)
+                     (#%host-expression odd?)
+                     __))
+                   (#%blanket-template
+                    ((#%host-expression map)
+                     (#%host-expression sqr)
+                     __))
+                   values))])
       (check-true (deforested? (syntax->datum
                                 (deforest-rewrite
                                   #`(thread #,@stx))))
                   "deforestation in arbitrary positions"))
-    (let ([stx (map make-right-chiral
-                    (syntax->list
-                     #'((#%partial-application
-                         ((#%host-expression filter)
-                          (#%host-expression string-upcase)))
-                        (#%partial-application
-                         ((#%host-expression foldl)
-                          (#%host-expression string-append)
-                          (#%host-expression "I"))))))])
+    (let ([stx (syntax->list
+                #'((#%blanket-template
+                    ((#%host-expression filter)
+                     (#%host-expression string-upcase)
+                     __))
+                   (#%blanket-template
+                    ((#%host-expression foldl)
+                     (#%host-expression string-append)
+                     (#%host-expression "I")
+                     __))))])
       (check-true (deforested? (syntax->datum
                                 (deforest-rewrite
                                   #`(thread #,@stx))))
@@ -87,19 +90,7 @@
       (check-true (deforested? (syntax->datum
                                 (deforest-rewrite
                                   #`(thread #,@stx))))
-                  "deforest fine-grained template forms"))
-    (let ([stx (syntax->list #'((#%blanket-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  __))
-                                (#%blanket-template
-                                 ((#%host-expression map)
-                                  (#%host-expression sqr)
-                                  __))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforest blanket template forms")))
+                  "deforest fine-grained template forms")))
    (test-suite
     "normalization"
     (test-normalize #'(thread

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -449,6 +449,10 @@
                     "p" "q")
                    "pabqab"
                    "threading without template")
+     (check-equal? ((☯ (~> (sort 3 1 2 #:key sqr)))
+                    <)
+                   (list 1 4 9)
+                   "pre-supplied keyword arguments with left chirality")
      (check-equal? ((☯ (thread add1
                                (* 2)
                                number->string
@@ -482,10 +486,10 @@
                     "p" "q")
                    "abpq"
                    "right-threading without template")
-     (check-equal? ((☯ (~>> △ (sort < #:key identity)))
+     (check-equal? ((☯ (~>> △ (sort < #:key sqr)))
                     (list 2 1 3))
-                   (list 1 2 3)
-                   "right-threading with keyword arg")
+                   (list 1 4 9)
+                   "pre-supplied keyword arguments with right chirality")
      ;; TODO: propagate threading side to nested clauses
      ;; (check-equal? (on ("p" "q")
      ;;                   (~>> (>< (string-append "a" "b"))


### PR DESCRIPTION
### Summary of Changes

This reduces (implicit) chirality of forms as indicated by left- or right-threading to an explicit use of a blanket template (i.e. `__`) in the expander, as discussed in [A Fine-grained Migraine](https://github.com/drym-org/qi/wiki/Qi-Compiler-Sync-Nov-24-2023#chirality-as-a-reducible-concept). This simplifies the core language by eliminating the `#%partial-application` form, and should reduce the number of patterns we need to match in deforestation and other compiler optimizations.

Note that we still retain the concept of chirality in the compiler for handling `clos`, for now.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
