### PR TITLE
More compiler tests

### DIFF
--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -537,18 +537,26 @@ the DSL.
       ;; "prarg" = "pre-supplied argument"
       ;; Note: use of currying here doesn't play well with bindings
       ;; because curry / curryr immediately evaluate their arguments
-      ;; and resolve any references to bindings at compile time,
-      ;; whereas a lambda delays evaluation until runtime when the
-      ;; reference is actually resolvable.
+      ;; and resolve any references to bindings at compile time.
+      ;; That's why we use a lambda which delays evaluation until runtime
+      ;; when the reference is actually resolvable. See "anaphoric references"
+      ;; in the compiler meeting notes,
+      ;; "The Artist Formerly Known as Bindingspec"
       [((~datum #%blanket-template)
         (natex prarg-pre ...+ (~datum __) prarg-post ...+))
-       #'(curry (curryr natex
-                        prarg-post ...)
-                prarg-pre ...)]
+       ;; "(curry (curryr ...) ...)"
+       #'(lambda largs
+           (apply
+            (lambda rargs
+              ((kw-helper natex rargs) prarg-post ...))
+            prarg-pre ...
+            largs))]
       [((~datum #%blanket-template) (natex prarg-pre ...+ (~datum __)))
+       ;; "curry"
        #'(lambda args
            (apply natex prarg-pre ... args))]
       [((~datum #%blanket-template)
         (natex (~datum __) prarg-post ...+))
+       ;; "curryr"
        #'(lambda args
            ((kw-helper natex args) prarg-post ...))])))

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 
 (provide (for-syntax compile-flow
-                     normalize-pass))
+                     normalize-pass
+                     fix))
 
 (require (for-syntax racket/base
                      syntax/parse
@@ -69,8 +70,8 @@
                      stx))
 
   (define (optimize-flow stx)
-    ;; (deforest-pass (normalize-pass stx))
-    (deforest-pass (normalize-pass stx))))
+    (deforest-pass
+      (normalize-pass stx))))
 
 ;; Transformation rules for the `as` binding form:
 ;;

--- a/qi-lib/flow/extended/syntax.rkt
+++ b/qi-lib/flow/extended/syntax.rkt
@@ -6,8 +6,7 @@
          blanket-template-form
          fine-template-form
          partial-application-form
-         any-stx
-         make-right-chiral)
+         any-stx)
 
 (require syntax/parse
          "../aux-syntax.rkt"

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -124,10 +124,7 @@
                    "fine-grained template forms")))
     (test-suite
      "producers"
-     (let ([stx (syntax->list #'((#%blanket-template
-                                  ((#%host-expression range)
-                                   (#%host-expression 10)
-                                   __))
+     (let ([stx (syntax->list #'((#%host-expression range)
                                  (#%blanket-template
                                   ((#%host-expression filter)
                                    (#%host-expression odd?)
@@ -138,16 +135,255 @@
                    "range"))
      (let ([stx (syntax->list #'((#%fine-template
                                   ((#%host-expression range)
-                                   (#%host-expression 10)
                                    _))
-                                 (#%fine-template
+                                 (#%blanket-template
                                   ((#%host-expression filter)
                                    (#%host-expression odd?)
-                                   _))))])
+                                   __))))])
        (check-true (deforested? (syntax->datum
                                  (deforest-rewrite
                                    #`(thread #,@stx))))
-                   "fine template in range")))
+                   "(range _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range _ _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range _ 10)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range _ _ _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range _ _ 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range _ 10 _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range _ 10 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 _ _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 _ 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 10 _)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range __)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 __)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range __ 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 10 __)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range __ 10 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 __ 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 10 1 __)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 10 __ 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range 0 __ 10 1)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   _
+                                   _))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "(range __ 0 10 1)")))
     (test-suite
      "consumers"
      (let ([stx (syntax->list #'((#%blanket-template

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -31,112 +31,162 @@
    ;; step in compilation) into account
    (test-suite
     "deforestation"
-    (let ([stx (syntax->list #'((#%blanket-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  __))))])
-      (check-false (deforested? (syntax->datum
+    (test-suite
+     "general"
+     (let ([stx (syntax->list #'((#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-false (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    #`(thread #,@stx))))
+                    "does not deforest single stream component in isolation"))
+     (let ([stx #'(#%blanket-template
+                   ((#%host-expression map)
+                    (#%host-expression sqr)
+                    __)
+                   ((#%host-expression filter)
+                    (#%host-expression odd?)
+                    __))])
+       (check-false (deforested? (syntax->datum
+                                  (deforest-rewrite
+                                    #`(thread #,stx))))
+                    "does not deforest map in the head position"))
+     ;; (~>> values (filter odd?) (map sqr) values)
+     (let ([stx (syntax->list
+                 #'(values
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression odd?)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression map)
+                      (#%host-expression sqr)
+                      __))
+                    values))])
+       (check-true (deforested? (syntax->datum
                                  (deforest-rewrite
                                    #`(thread #,@stx))))
-                   "does not deforest single stream component in isolation"))
-    (let ([stx (syntax->list #'((#%blanket-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  __))
-                                (#%blanket-template
-                                 ((#%host-expression map)
-                                  (#%host-expression sqr)
-                                  __))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforest filter"))
-    (let ([stx (syntax->list #'((#%blanket-template
-                                 ((#%host-expression range)
-                                  (#%host-expression 10)
-                                  __))
-                                (#%blanket-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  __))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforest range"))
-    (let ([stx (syntax->list #'((#%blanket-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  __))
-                                (esc (#%host-expression car))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforest car"))
-    (let ([stx (syntax->list #'((#%blanket-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  __))
-                                (#%blanket-template
-                                 ((#%host-expression map)
-                                  (#%host-expression sqr)
-                                  __))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforest range"))
-    (let ([stx #'(#%blanket-template
-                  ((#%host-expression map)
-                   (#%host-expression sqr)
-                   __)
-                  ((#%host-expression filter)
-                   (#%host-expression odd?)
-                   __))])
-      (check-false (deforested? (syntax->datum
+                   "deforestation in arbitrary positions"))
+     (let ([stx (syntax->list
+                 #'(values
+                    (#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression string-upcase)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression foldl)
+                      (#%host-expression string-append)
+                      (#%host-expression "I")
+                      __))
+                    values))])
+       (check-true (deforested? (syntax->datum
                                  (deforest-rewrite
-                                   #`(thread #,stx))))
-                   "does not deforest map in the head position"))
-    ;; (~>> values (filter odd?) (map sqr) values)
-    (let ([stx (syntax->list
-                #'(values
-                   (#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression odd?)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression map)
-                     (#%host-expression sqr)
-                     __))
-                   values))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforestation in arbitrary positions"))
-    (let ([stx (syntax->list
-                #'((#%blanket-template
-                    ((#%host-expression filter)
-                     (#%host-expression string-upcase)
-                     __))
-                   (#%blanket-template
-                    ((#%host-expression foldl)
-                     (#%host-expression string-append)
-                     (#%host-expression "I")
-                     __))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforestation in arbitrary positions"))
-    (let ([stx (syntax->list #'((#%fine-template
-                                 ((#%host-expression filter)
-                                  (#%host-expression odd?)
-                                  _))
-                                (#%fine-template
-                                 ((#%host-expression map)
-                                  (#%host-expression sqr)
-                                  _))))])
-      (check-true (deforested? (syntax->datum
-                                (deforest-rewrite
-                                  #`(thread #,@stx))))
-                  "deforest fine-grained template forms")))
+                                   #`(thread #,@stx))))
+                   "deforestation in arbitrary positions")))
+    (test-suite
+     "transformers"
+     (let ([stx (syntax->list #'((#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))
+                                 (#%blanket-template
+                                  ((#%host-expression map)
+                                   (#%host-expression sqr)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "filter"))
+     (let ([stx (syntax->list #'((#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))
+                                 (#%blanket-template
+                                  ((#%host-expression map)
+                                   (#%host-expression sqr)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "filter-map (two transformers)"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   _))
+                                 (#%fine-template
+                                  ((#%host-expression map)
+                                   (#%host-expression sqr)
+                                   _))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "fine-grained template forms")))
+    (test-suite
+     "producers"
+     (let ([stx (syntax->list #'((#%blanket-template
+                                  ((#%host-expression range)
+                                   (#%host-expression 10)
+                                   __))
+                                 (#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "range"))
+     (let ([stx (syntax->list #'((#%fine-template
+                                  ((#%host-expression range)
+                                   (#%host-expression 10)
+                                   _))
+                                 (#%fine-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   _))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "fine template in range")))
+    (test-suite
+     "consumers"
+     (let ([stx (syntax->list #'((#%blanket-template
+                                  ((#%host-expression filter)
+                                   (#%host-expression odd?)
+                                   __))
+                                 (esc (#%host-expression car))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "car"))
+     (let ([stx (syntax->list
+                 #'((#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression string-upcase)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression foldl)
+                      (#%host-expression string-append)
+                      (#%host-expression "I")
+                      __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "foldl"))
+     (let ([stx (syntax->list
+                 #'((#%blanket-template
+                     ((#%host-expression filter)
+                      (#%host-expression string-upcase)
+                      __))
+                    (#%blanket-template
+                     ((#%host-expression foldr)
+                      (#%host-expression string-append)
+                      (#%host-expression "I")
+                      __))))])
+       (check-true (deforested? (syntax->datum
+                                 (deforest-rewrite
+                                   #`(thread #,@stx))))
+                   "foldr"))))
    (test-suite
     "normalization"
     (test-normalize #'(thread

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -705,9 +705,13 @@
                    "abc")
      (check-equal? ((☯ (string-append __ "c"))
                     "a" "b")
-                   "abc"))
+                   "abc")
+     (check-equal? ((☯ (sort < __ #:key sqr))
+                    3 1 2)
+                   (list 1 4 9)
+                   "keyword arguments in a blanket template"))
     (test-suite
-     "template with single argument"
+     "fine template with single argument"
      (check-false ((☯ (apply > _))
                    (list 1 2 3)))
      (check-true ((☯ (apply > _))
@@ -726,13 +730,21 @@
      (check-equal? ((☯ (foldl string-append "" _))
                     (list "a" "b" "c"))
                    "cba"
-                   "foldl in predicate"))
+                   "foldl in predicate")
+     (check-equal? ((☯ (sort < 3 _ 2 #:key sqr))
+                    1)
+                   (list 1 4 9)
+                   "keyword arguments in a fine template"))
     (test-suite
-     "template with multiple arguments"
+     "fine template with multiple arguments"
      (check-true ((☯ (< 1 _ 5 _ 10)) 3 7)
                  "template with multiple arguments")
      (check-false ((☯ (< 1 _ 5 _ 10)) 3 5)
-                  "template with multiple arguments"))
+                  "template with multiple arguments")
+     (check-equal? ((☯ (sort < _ _ 2 #:key sqr))
+                    3 1)
+                   (list 1 4 9)
+                   "keyword arguments in a fine template"))
     (test-suite
      "templating behavior is contained to intentional template syntax"
      (check-exn exn:fail:syntax?

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -1567,8 +1567,7 @@
      (check-equal? ((☯ (~>> (map string-upcase) (foldl string-append "I")))
                     (list "a" "b" "c"))
                    "CBAI")
-     (check-equal? ((☯ (~>> (range 10) (map sqr) car))
-                    0)
+     (check-equal? ((☯ (~>> (range 10) (map sqr) car)))
                    0)))))
 
 (module+ main


### PR DESCRIPTION
### Summary of Changes

This adds (failing) tests for deforestation of all permutations of templates, and also fixes an ["anaphoric references"](https://github.com/drym-org/qi/wiki/Qi-Compiler-Sync-Nov-11-2022) issue with compiling blanket templates in connection with bindings, which we had fixed a while back for compiling partial applications, but which we hadn't noticed also affects blanket templates. I added a failing test for this yesterday and this PR resolves that test by adding the fix. So now, all tests with `make test-flow` are passing again. This also adds a couple of tests to validate use of keyword arguments in templates.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
