### PR TITLE
Phase shifting

### DIFF
--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -10,7 +10,6 @@
 
 (define-syntax-class literal
   (pattern
-   ;; TODO: would be ideal to also match literal vectors, boxes and prefabs
    (~or* expr:boolean
          expr:char
          expr:string

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -10,15 +10,15 @@
                      "syntax.rkt"
                      "../aux-syntax.rkt"
                      "util.rkt"
-                     "debug.rkt")
+                     "debug.rkt"
+                     "normalize.rkt"
+                     "deforest.rkt")
          "impl.rkt"
          (only-in racket/list make-list)
          racket/function
          racket/undefined
          (prefix-in fancy: fancy-app)
-         racket/list
-         "deforest.rkt"
-         "normalize.rkt")
+         racket/list)
 
 (begin-for-syntax
 

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -1,8 +1,7 @@
 #lang racket/base
 
 (provide (for-syntax compile-flow
-                     normalize-pass
-                     fix))
+                     normalize-pass))
 
 (require (for-syntax racket/base
                      syntax/parse
@@ -10,7 +9,8 @@
                      (only-in racket/list make-list)
                      "syntax.rkt"
                      "../aux-syntax.rkt"
-                     macro-debugger/emit)
+                     "util.rkt"
+                     "debug.rkt")
          "impl.rkt"
          (only-in racket/list make-list)
          racket/function
@@ -22,38 +22,10 @@
 
 (begin-for-syntax
 
-  ;; currently does not distinguish substeps of a parent expansion step
-  (define-syntax-rule (qi-expansion-step name stx0 stx1)
-    (let ()
-      (emit-local-step stx0 stx1 #:id #'name)
-      stx1))
-
-  ;; TODO: move this to a common utils module for use in all
-  ;; modules implementing optimization passes
-  (define-syntax-rule (define-qi-expansion-step (name stx0)
-                        body ...)
-    (define (name stx0)
-      (let ([stx1 (let () body ...)])
-        (qi-expansion-step name stx0 stx1))))
-
   ;; note: this does not return compiled code but instead,
   ;; syntax whose expansion compiles the code
   (define (compile-flow stx)
     (process-bindings (optimize-flow stx)))
-
-  ;; Applies f repeatedly to the init-val terminating the loop if the
-  ;; result of f is #f or the new syntax object is eq? to the previous
-  ;; (possibly initial) one.
-  ;;
-  ;; Caveats:
-  ;;   * the syntax object is not inspected, only eq? is used
-  ;;   * comparison is performed only between consecutive steps (does not handle cyclic occurences)
-  (define ((fix f) init-val)
-    (let ([new-val (f init-val)])
-      (if (or (not new-val)
-              (eq? new-val init-val))
-          init-val
-          ((fix f) new-val))))
 
   (define (deforest-pass stx)
     (find-and-map/qi (fix deforest-rewrite)
@@ -105,26 +77,6 @@
 ;;          (☯ (~> flo ... (... (~> (esc (λ (x) (set! name x))) ⏚) ...)))))
 
 (begin-for-syntax
-
-  (define (find-and-map f stx)
-    ;; f : syntax? -> (or/c syntax? #f)
-    (match stx
-      [(? syntax?) (let ([stx^ (f stx)])
-                     (or stx^ (datum->syntax stx
-                                (find-and-map f (syntax-e stx))
-                                stx
-                                stx)))]
-      [(cons a d) (cons (find-and-map f a)
-                        (find-and-map f d))]
-      [_ stx]))
-
-  (define (find-and-map/qi f stx)
-    ;; #%host-expression is a Racket macro defined by syntax-spec
-    ;; that resumes expansion of its sub-expression with an
-    ;; expander environment containing the original surface bindings
-    (find-and-map (syntax-parser [((~datum #%host-expression) e:expr) this-syntax]
-                                 [_ (f this-syntax)])
-                  stx))
 
   ;; (as name) → (~> (esc (λ (x) (set! name x))) ⏚)
   ;; TODO: use a box instead of set!

--- a/qi-lib/flow/core/debug.rkt
+++ b/qi-lib/flow/core/debug.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+(provide qi-expansion-step
+         define-qi-expansion-step)
+
+(require macro-debugger/emit)
+
+;; These macros emit expansion "events" that allow the macro
+;; stepper to report stages in the expansion of an expression,
+;; giving us visibility into this process for debugging purposes.
+;; Note that this currently does not distinguish substeps
+;; of a parent expansion step.
+(define-syntax-rule (qi-expansion-step name stx0 stx1)
+  (let ()
+    (emit-local-step stx0 stx1 #:id #'name)
+    stx1))
+
+(define-syntax-rule (define-qi-expansion-step (name stx0)
+                      body ...)
+  (define (name stx0)
+    (let ([stx1 (let () body ...)])
+      (qi-expansion-step name stx0 stx1))))

--- a/qi-lib/flow/core/deforest.rkt
+++ b/qi-lib/flow/core/deforest.rkt
@@ -1,10 +1,10 @@
 #lang racket/base
 
-(provide (for-syntax deforest-rewrite))
+(provide deforest-rewrite)
 
-(require (for-syntax racket/base
-                     syntax/parse
-                     racket/syntax-srcloc)
+(require (for-syntax racket/base)
+         syntax/parse
+         racket/syntax-srcloc
          racket/performance-hint
          racket/match
          racket/list
@@ -25,308 +25,304 @@
     [(_ f) f]
     [(_ [op f] rest ...) (op f (inline-compose1 rest ...))]))
 
-(begin-for-syntax
+;; Partially reconstructs original flow expressions. The chirality
+;; is lost and the form is already normalized at this point though!
+(define (prettify-flow-syntax stx)
+  (syntax-parse stx
+    #:datum-literals (#%host-expression esc #%blanket-template #%fine-template)
+    (((~literal thread)
+      expr ...)
+     #`(~> #,@(map prettify-flow-syntax (syntax->list #'(expr ...)))))
+    (((~or #%blanket-template #%fine-template)
+      (expr ...))
+     (map prettify-flow-syntax (syntax->list #'(expr ...))))
+    ((#%host-expression expr) #'expr)
+    ((esc expr) (prettify-flow-syntax #'expr))
+    (expr #'expr)))
 
-  ;; Partially reconstructs original flow expressions. The chirality
-  ;; is lost and the form is already normalized at this point though!
-  (define (prettify-flow-syntax stx)
-    (syntax-parse stx
-      #:datum-literals (#%host-expression esc #%blanket-template #%fine-template)
-      (((~literal thread)
-        expr ...)
-       #`(~> #,@(map prettify-flow-syntax (syntax->list #'(expr ...)))))
-      (((~or #%blanket-template #%fine-template)
-        (expr ...))
-       (map prettify-flow-syntax (syntax->list #'(expr ...))))
-      ((#%host-expression expr) #'expr)
-      ((esc expr) (prettify-flow-syntax #'expr))
-      (expr #'expr)))
+;; Special "curry"ing for #%fine-templates. All #%host-expressions
+;; are passed as they are and all (~datum _) are replaced by wrapper
+;; lambda arguments.
+(define ((make-fine-curry argstx minargs maxargs form-stx) ctx name)
+  (define argstxlst (syntax->list argstx))
+  (define numargs (length argstxlst))
+  (cond ((< numargs minargs)
+         (raise-syntax-error (syntax->datum name)
+                             (format "too few arguments - given ~a - accepts at least ~a"
+                                     numargs minargs)
+                             (prettify-flow-syntax ctx)
+                             (prettify-flow-syntax form-stx)))
+        ((> numargs maxargs)
+         (raise-syntax-error (syntax->datum name)
+                             (format "too many arguments - given ~a - accepts at most ~a"
+                                     numargs maxargs)
+                             (prettify-flow-syntax ctx)
+                             (prettify-flow-syntax form-stx))))
+  (define temporaries (generate-temporaries argstxlst))
+  (define-values (allargs tmpargs)
+    (for/fold ((all '())
+               (tmps '())
+               #:result (values (reverse all)
+                                (reverse tmps)))
+              ((tmp (in-list temporaries))
+               (arg (in-list argstxlst)))
+      (syntax-parse arg
+        #:datum-literals (#%host-expression)
+        ((#%host-expression ex)
+         (values (cons #'ex all)
+                 tmps))
+        ((~datum _)
+         (values (cons tmp all)
+                 (cons tmp tmps))))))
+  (with-syntax (((carg ...) tmpargs)
+                ((aarg ...) allargs))
+    #'(λ (proc)
+        (λ (carg ...)
+          (proc aarg ...)))))
 
-  ;; Special "curry"ing for #%fine-templates. All #%host-expressions
-  ;; are passed as they are and all (~datum _) are replaced by wrapper
-  ;; lambda arguments.
-  (define ((make-fine-curry argstx minargs maxargs form-stx) ctx name)
-    (define argstxlst (syntax->list argstx))
-    (define numargs (length argstxlst))
-    (cond ((< numargs minargs)
-           (raise-syntax-error (syntax->datum name)
-                               (format "too few arguments - given ~a - accepts at least ~a"
-                                       numargs minargs)
-                               (prettify-flow-syntax ctx)
-                               (prettify-flow-syntax form-stx)))
-          ((> numargs maxargs)
+;; Special curry for #%blanket-template. Raises syntax error if
+;; there are too many arguments. If the number of arguments is
+;; exactly the maximum, wraps into lambda without any arguments. If
+;; less than maximum, curries it from both left and right.
+(define ((make-blanket-curry prestx poststx maxargs form-stx) ctx name)
+  (define prelst (syntax->list prestx))
+  (define postlst (syntax->list poststx))
+  (define numargs (+ (length prelst) (length postlst)))
+  (with-syntax (((pre-arg ...) prelst)
+                ((post-arg ...) postlst))
+    (cond ((> numargs maxargs)
            (raise-syntax-error (syntax->datum name)
                                (format "too many arguments - given ~a - accepts at most ~a"
                                        numargs maxargs)
                                (prettify-flow-syntax ctx)
-                               (prettify-flow-syntax form-stx))))
-    (define temporaries (generate-temporaries argstxlst))
-    (define-values (allargs tmpargs)
-      (for/fold ((all '())
-                 (tmps '())
-                 #:result (values (reverse all)
-                                  (reverse tmps)))
-                ((tmp (in-list temporaries))
-                 (arg (in-list argstxlst)))
-        (syntax-parse arg
-          #:datum-literals (#%host-expression)
-          ((#%host-expression ex)
-           (values (cons #'ex all)
-                   tmps))
-          ((~datum _)
-           (values (cons tmp all)
-                   (cons tmp tmps))))))
-    (with-syntax (((carg ...) tmpargs)
-                  ((aarg ...) allargs))
-      #'(λ (proc)
-          (λ (carg ...)
-            (proc aarg ...)))))
+                               (prettify-flow-syntax form-stx)))
+          ((= numargs maxargs)
+           #'(λ (v)
+               (λ ()
+                 (v pre-arg ... post-arg ...))))
+          (else
+           #'(λ (v)
+               (λ rest
+                 (apply v pre-arg ...
+                        (append rest
+                                (list post-arg ...)))))))))
 
-  ;; Special curry for #%blanket-template. Raises syntax error if
-  ;; there are too many arguments. If the number of arguments is
-  ;; exactly the maximum, wraps into lambda without any arguments. If
-  ;; less than maximum, curries it from both left and right.
-  (define ((make-blanket-curry prestx poststx maxargs form-stx) ctx name)
-    (define prelst (syntax->list prestx))
-    (define postlst (syntax->list poststx))
-    (define numargs (+ (length prelst) (length postlst)))
-    (with-syntax (((pre-arg ...) prelst)
-                  ((post-arg ...) postlst))
-      (cond ((> numargs maxargs)
-             (raise-syntax-error (syntax->datum name)
-                                 (format "too many arguments - given ~a - accepts at most ~a"
-                                         numargs maxargs)
-                                 (prettify-flow-syntax ctx)
-                                 (prettify-flow-syntax form-stx)))
-            ((= numargs maxargs)
-             #'(λ (v)
-                 (λ ()
-                   (v pre-arg ... post-arg ...))))
-            (else
-             #'(λ (v)
-                 (λ rest
-                   (apply v pre-arg ...
-                          (append rest
-                                  (list post-arg ...)))))))))
+;; Unifying producer curry makers. The ellipsis escaping allows for
+;; simple specification of pattern variable names as bound in the
+;; syntax pattern.
+(define-syntax make-producer-curry
+  (syntax-rules ()
+    ((_ min-args max-args
+        blanket? pre-arg post-arg
+        fine? arg
+        form-stx)
+     (cond
+       ((attribute blanket?)
+        (make-blanket-curry #'(pre-arg (... ...))
+                            #'(post-arg (... ...))
+                            max-args
+                            #'form-stx
+                            ))
+       ((attribute fine?)
+        (make-fine-curry #'(arg (... ...)) min-args max-args #'form-stx))
+       (else
+        (λ (ctx name) #'(λ (v) v)))))))
 
-  ;; Unifying producer curry makers. The ellipsis escaping allows for
-  ;; simple specification of pattern variable names as bound in the
-  ;; syntax pattern.
-  (define-syntax make-producer-curry
-    (syntax-rules ()
-      ((_ min-args max-args
-          blanket? pre-arg post-arg
-          fine? arg
-          form-stx)
-       (cond
-         ((attribute blanket?)
-          (make-blanket-curry #'(pre-arg (... ...))
-                              #'(post-arg (... ...))
-                              max-args
-                              #'form-stx
-                              ))
-         ((attribute fine?)
-          (make-fine-curry #'(arg (... ...)) min-args max-args #'form-stx))
-         (else
-          (λ (ctx name) #'(λ (v) v)))))))
+;; Used for producing the stream from particular
+;; expressions. Implicit producer is list->cstream-next and it is
+;; not created by using this class but rather explicitly used when
+;; no syntax class producer is matched.
+(define-syntax-class fusable-stream-producer
+  #:attributes (next prepare contract name curry)
+  #:datum-literals (#%host-expression #%blanket-template #%fine-template esc __)
+  ;; Explicit range producers.
+  (pattern (~and (~or (esc (#%host-expression (~literal range)))
+                      (~and (#%fine-template
+                             ((#%host-expression (~literal range))
+                              arg ...))
+                            fine?)
+                      (~and (#%blanket-template
+                             ((#%host-expression (~literal range))
+                              (#%host-expression pre-arg) ...
+                              __
+                              (#%host-expression post-arg) ...))
+                            blanket?))
+                 form-stx)
+    #:attr next #'range->cstream-next
+    #:attr prepare #'range->cstream-prepare
+    #:attr contract #'(->* (real?) (real? real?) any)
+    #:attr name #'range
+    #:attr curry (make-producer-curry 1 3
+                                      blanket? pre-arg post-arg
+                                      fine? arg
+                                      form-stx))
 
-  ;; Used for producing the stream from particular
-  ;; expressions. Implicit producer is list->cstream-next and it is
-  ;; not created by using this class but rather explicitly used when
-  ;; no syntax class producer is matched.
-  (define-syntax-class fusable-stream-producer
-    #:attributes (next prepare contract name curry)
-    #:datum-literals (#%host-expression #%blanket-template #%fine-template esc __)
-    ;; Explicit range producers.
-    (pattern (~and (~or (esc (#%host-expression (~literal range)))
-                        (~and (#%fine-template
-                               ((#%host-expression (~literal range))
-                                arg ...))
-                              fine?)
-                        (~and (#%blanket-template
-                               ((#%host-expression (~literal range))
-                                (#%host-expression pre-arg) ...
-                                __
-                                (#%host-expression post-arg) ...))
-                              blanket?))
-                   form-stx)
-             #:attr next #'range->cstream-next
-             #:attr prepare #'range->cstream-prepare
-             #:attr contract #'(->* (real?) (real? real?) any)
-             #:attr name #'range
-             #:attr curry (make-producer-curry 1 3
-                                               blanket? pre-arg post-arg
-                                               fine? arg
-                                               form-stx))
+  ;; The implicit stream producer from plain list.
+  (pattern (~literal list->cstream)
+    #:attr next #'list->cstream-next
+    #:attr prepare #'list->cstream-prepare
+    #:attr contract #'(-> list? any)
+    #:attr name #''list->cstream
+    #:attr curry (λ (ctx name) #'(λ (v) v))))
 
-    ;; The implicit stream producer from plain list.
-    (pattern (~literal list->cstream)
-             #:attr next #'list->cstream-next
-             #:attr prepare #'list->cstream-prepare
-             #:attr contract #'(-> list? any)
-             #:attr name #''list->cstream
-             #:attr curry (λ (ctx name) #'(λ (v) v))))
+;; Matches any stream transformer that can be in the head position
+;; of the fused sequence even when there is no explicit
+;; producer. Procedures accepting variable number of arguments like
+;; `map` cannot be in this class.
+(define-syntax-class fusable-stream-transformer0
+  #:attributes (f next)
+  #:datum-literals (#%host-expression #%blanket-template __ _ #%fine-template)
+  (pattern (~or (#%blanket-template
+                 ((#%host-expression (~literal filter))
+                  (#%host-expression f)
+                  __))
+                (#%fine-template
+                 ((#%host-expression (~literal filter))
+                  (#%host-expression f)
+                  _)))
+    #:attr next #'filter-cstream-next))
 
-  ;; Matches any stream transformer that can be in the head position
-  ;; of the fused sequence even when there is no explicit
-  ;; producer. Procedures accepting variable number of arguments like
-  ;; `map` cannot be in this class.
-  (define-syntax-class fusable-stream-transformer0
-    #:attributes (f next)
-    #:datum-literals (#%host-expression #%blanket-template __ _ #%fine-template)
-    (pattern (~or (#%blanket-template
-                   ((#%host-expression (~literal filter))
-                    (#%host-expression f)
-                    __))
-                  (#%fine-template
-                   ((#%host-expression (~literal filter))
-                    (#%host-expression f)
-                    _)))
-      #:attr next #'filter-cstream-next))
+;; All implemented stream transformers - within the stream, only
+;; single value is being passed and therefore procedures like `map`
+;; can (and should) be matched.
+(define-syntax-class fusable-stream-transformer
+  #:attributes (f next)
+  #:datum-literals (#%host-expression #%blanket-template __ _ #%fine-template)
+  (pattern (~or (#%blanket-template
+                 ((#%host-expression (~literal map))
+                  (#%host-expression f)
+                  __))
+                (#%fine-template
+                 ((#%host-expression (~literal map))
+                  (#%host-expression f)
+                  _)))
+    #:attr next #'map-cstream-next)
 
-  ;; All implemented stream transformers - within the stream, only
-  ;; single value is being passed and therefore procedures like `map`
-  ;; can (and should) be matched.
-  (define-syntax-class fusable-stream-transformer
-    #:attributes (f next)
-    #:datum-literals (#%host-expression #%blanket-template __ _ #%fine-template)
-    (pattern (~or (#%blanket-template
-                   ((#%host-expression (~literal map))
-                    (#%host-expression f)
-                    __))
-                  (#%fine-template
-                   ((#%host-expression (~literal map))
-                    (#%host-expression f)
-                    _)))
-      #:attr next #'map-cstream-next)
+  (pattern (~or (#%blanket-template
+                 ((#%host-expression (~literal filter))
+                  (#%host-expression f)
+                  __))
+                (#%fine-template
+                 ((#%host-expression (~literal filter))
+                  (#%host-expression f)
+                  _)))
+    #:attr next #'filter-cstream-next))
 
-    (pattern (~or (#%blanket-template
-                   ((#%host-expression (~literal filter))
-                    (#%host-expression f)
-                    __))
-                  (#%fine-template
-                   ((#%host-expression (~literal filter))
-                    (#%host-expression f)
-                    _)))
-      #:attr next #'filter-cstream-next))
+;; Terminates the fused sequence (consumes the stream) and produces
+;; an actual result value.
+(define-syntax-class fusable-stream-consumer
+  #:attributes (end)
+  #:datum-literals (#%host-expression #%blanket-template _ __ #%fine-template esc)
+  (pattern (~or (#%blanket-template
+                 ((#%host-expression (~literal foldr))
+                  (#%host-expression op)
+                  (#%host-expression init)
+                  __))
+                (#%fine-template
+                 ((#%host-expression (~literal foldr))
+                  (#%host-expression op)
+                  (#%host-expression init)
+                  _)))
+    #:attr end #'(foldr-cstream-next op init))
 
-  ;; Terminates the fused sequence (consumes the stream) and produces
-  ;; an actual result value.
-  (define-syntax-class fusable-stream-consumer
-    #:attributes (end)
-    #:datum-literals (#%host-expression #%blanket-template _ __ #%fine-template esc)
-    (pattern (~or (#%blanket-template
-                   ((#%host-expression (~literal foldr))
-                    (#%host-expression op)
-                    (#%host-expression init)
-                    __))
-                  (#%fine-template
-                   ((#%host-expression (~literal foldr))
-                    (#%host-expression op)
-                    (#%host-expression init)
-                    _)))
-             #:attr end #'(foldr-cstream-next op init))
+  (pattern (~or (#%blanket-template
+                 ((#%host-expression (~literal foldl))
+                  (#%host-expression op)
+                  (#%host-expression init)
+                  __))
+                (#%fine-template
+                 ((#%host-expression (~literal foldl))
+                  (#%host-expression op)
+                  (#%host-expression init)
+                  _)))
+    #:attr end #'(foldl-cstream-next op init))
 
-    (pattern (~or (#%blanket-template
-                   ((#%host-expression (~literal foldl))
-                    (#%host-expression op)
-                    (#%host-expression init)
-                    __))
-                  (#%fine-template
-                   ((#%host-expression (~literal foldl))
-                    (#%host-expression op)
-                    (#%host-expression init)
-                    _)))
-             #:attr end #'(foldl-cstream-next op init))
+  (pattern (~or (esc (#%host-expression (~literal car)))
+                (#%fine-template
+                 ((#%host-expression (~literal car))
+                  _))
+                (#%blanket-template
+                 ((#%host-expression (~literal car))
+                  __)))
+    #:attr end #'(car-cstream-next))
 
-    (pattern (~or (esc (#%host-expression (~literal car)))
-                  (#%fine-template
-                   ((#%host-expression (~literal car))
-                    _))
-                  (#%blanket-template
-                   ((#%host-expression (~literal car))
-                    __)))
-             #:attr end #'(car-cstream-next))
+  (pattern (~literal cstream->list)
+    #:attr end #'(cstream-next->list)))
 
-    (pattern (~literal cstream->list)
-             #:attr end #'(cstream-next->list)))
+;; Used only in deforest-rewrite to properly recognize the end of
+;; fusable sequence.
+(define-syntax-class non-fusable
+  (pattern (~not (~or _:fusable-stream-transformer
+                      _:fusable-stream-producer
+                      _:fusable-stream-consumer))))
 
-  ;; Used only in deforest-rewrite to properly recognize the end of
-  ;; fusable sequence.
-  (define-syntax-class non-fusable
-    (pattern (~not (~or _:fusable-stream-transformer
-                        _:fusable-stream-producer
-                        _:fusable-stream-consumer))))
-
-  ;; Generates a syntax for the fused operation for given
-  ;; sequence. The syntax list must already be in the following form:
-  ;; (producer transformer ... consumer)
-  (define (generate-fused-operation ops ctx)
-    (syntax-parse (reverse ops)
-      [(c:fusable-stream-consumer
-        t:fusable-stream-transformer ...
-        p:fusable-stream-producer)
-       ;; A static runtime contract is placed at the beginning of the
-       ;; fused sequence. And runtime checks for consumers are in
-       ;; their respective implementation procedure.
-       #`(esc
-          (#,((attribute p.curry) ctx (attribute p.name))
-           (contract p.contract
-                     (p.prepare
-                      (#,@#'c.end
-                       (inline-compose1 [t.next t.f] ...
-                                        p.next)
-                       '#,(prettify-flow-syntax ctx)
-                       #,(syntax-srcloc ctx)))
-                     p.name
+;; Generates a syntax for the fused operation for given
+;; sequence. The syntax list must already be in the following form:
+;; (producer transformer ... consumer)
+(define (generate-fused-operation ops ctx)
+  (syntax-parse (reverse ops)
+    [(c:fusable-stream-consumer
+      t:fusable-stream-transformer ...
+      p:fusable-stream-producer)
+     ;; A static runtime contract is placed at the beginning of the
+     ;; fused sequence. And runtime checks for consumers are in
+     ;; their respective implementation procedure.
+     #`(esc
+        (#,((attribute p.curry) ctx (attribute p.name))
+         (contract p.contract
+                   (p.prepare
+                    (#,@#'c.end
+                     (inline-compose1 [t.next t.f] ...
+                                      p.next)
                      '#,(prettify-flow-syntax ctx)
-                     #f
-                     #,(syntax-srcloc ctx))))]))
+                     #,(syntax-srcloc ctx)))
+                   p.name
+                   '#,(prettify-flow-syntax ctx)
+                   #f
+                   #,(syntax-srcloc ctx))))]))
 
-  ;; Performs one step of deforestation rewrite. Should be used as
-  ;; many times as needed - until it returns the source syntax
-  ;; unchanged.
-  (define (deforest-rewrite stx)
-    (syntax-parse stx
-      [((~datum thread) _0:non-fusable ...
-                        p:fusable-stream-producer
-                        ;; There can be zero transformers here:
-                        t:fusable-stream-transformer ...
-                        c:fusable-stream-consumer
-                        _1 ...)
-       #:with fused (generate-fused-operation
-                     (syntax->list #'(p t ... c))
-                     stx)
-       #'(thread _0 ... fused _1 ...)]
-      [((~datum thread) _0:non-fusable ...
-                        t1:fusable-stream-transformer0
-                        t:fusable-stream-transformer ...
-                        c:fusable-stream-consumer
-                        _1 ...)
-       #:with fused (generate-fused-operation
-                     (syntax->list #'(list->cstream t1 t ... c))
-                     stx)
-       #'(thread _0 ... fused _1 ...)]
-      [((~datum thread) _0:non-fusable ...
-                        p:fusable-stream-producer
-                        ;; Must be 1 or more transformers here:
-                        t:fusable-stream-transformer ...+
-                        _1 ...)
-       #:with fused (generate-fused-operation
-                     (syntax->list #'(p t ... cstream->list))
-                     stx)
-       #'(thread _0 ... fused _1 ...)]
-      [((~datum thread) _0:non-fusable ...
-                        f1:fusable-stream-transformer0
-                        f:fusable-stream-transformer ...+
-                        _1 ...)
-       #:with fused (generate-fused-operation
-                     (syntax->list #'(list->cstream f1 f ... cstream->list))
-                     stx)
-       #'(thread _0 ... fused _1 ...)]
-      [_ this-syntax]))
-
-  )
+;; Performs one step of deforestation rewrite. Should be used as
+;; many times as needed - until it returns the source syntax
+;; unchanged.
+(define (deforest-rewrite stx)
+  (syntax-parse stx
+    [((~datum thread) _0:non-fusable ...
+                      p:fusable-stream-producer
+                      ;; There can be zero transformers here:
+                      t:fusable-stream-transformer ...
+                      c:fusable-stream-consumer
+                      _1 ...)
+     #:with fused (generate-fused-operation
+                   (syntax->list #'(p t ... c))
+                   stx)
+     #'(thread _0 ... fused _1 ...)]
+    [((~datum thread) _0:non-fusable ...
+                      t1:fusable-stream-transformer0
+                      t:fusable-stream-transformer ...
+                      c:fusable-stream-consumer
+                      _1 ...)
+     #:with fused (generate-fused-operation
+                   (syntax->list #'(list->cstream t1 t ... c))
+                   stx)
+     #'(thread _0 ... fused _1 ...)]
+    [((~datum thread) _0:non-fusable ...
+                      p:fusable-stream-producer
+                      ;; Must be 1 or more transformers here:
+                      t:fusable-stream-transformer ...+
+                      _1 ...)
+     #:with fused (generate-fused-operation
+                   (syntax->list #'(p t ... cstream->list))
+                   stx)
+     #'(thread _0 ... fused _1 ...)]
+    [((~datum thread) _0:non-fusable ...
+                      f1:fusable-stream-transformer0
+                      f:fusable-stream-transformer ...+
+                      _1 ...)
+     #:with fused (generate-fused-operation
+                   (syntax->list #'(list->cstream f1 f ... cstream->list))
+                   stx)
+     #'(thread _0 ... fused _1 ...)]
+    [_ this-syntax]))
 
 (begin-encourage-inline
 

--- a/qi-lib/flow/core/normalize.rkt
+++ b/qi-lib/flow/core/normalize.rkt
@@ -1,67 +1,64 @@
 #lang racket/base
 
-(provide (for-syntax normalize-rewrite))
+(provide normalize-rewrite)
 
-(require (for-syntax racket/base
-                     syntax/parse))
+(require syntax/parse)
 
-(begin-for-syntax
-
-  ;; 0. "Qi-normal form"
-  (define (normalize-rewrite stx)
-    (syntax-parse stx
-      ;; "deforestation" for values
-      ;; (~> (pass f) (>< g)) → (>< (if f g ⏚))
-      [((~datum thread) _0 ... ((~datum pass) f) ((~datum amp) g) _1 ...)
-       #'(thread _0 ... (amp (if f g ground)) _1 ...)]
-      ;; merge amps in sequence
-      [((~datum thread) _0 ... ((~datum amp) f) ((~datum amp) g) _1 ...)
-       #'(thread _0 ... (amp (thread f g)) _1 ...)]
-      ;; merge pass filters in sequence
-      [((~datum thread) _0 ... ((~datum pass) f) ((~datum pass) g) _1 ...)
-       #'(thread _0 ... (pass (and f g)) _1 ...)]
-      ;; collapse deterministic conditionals
-      [((~datum if) (~datum #t) f g) #'f]
-      [((~datum if) (~datum #f) f g) #'g]
-      ;; trivial threading form
-      [((~datum thread) f)
-       #'f]
-      ;; associative laws for ~>
-      [((~datum thread) _0 ... ((~datum thread) f ...) _1 ...) ; note: greedy matching
-       #'(thread _0 ... f ... _1 ...)]
-      ;; left and right identity for ~>
-      [((~datum thread) _0 ... (~datum _) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      ;; composition of identity flows is the identity flow
-      [((~datum thread) (~datum _) ...)
-       #'_]
-      ;; identity flows composed using a relay
-      [((~datum relay) (~datum _) ...)
-       #'_]
-      ;; amp and identity
-      [((~datum amp) (~datum _))
-       #'_]
-      ;; trivial tee junction
-      [((~datum tee) f)
-       #'f]
-      ;; merge adjacent gens in a tee junction
-      [((~datum tee) _0 ... ((~datum gen) a ...) ((~datum gen) b ...) _1 ...)
-       #'(tee _0 ... (gen a ... b ...) _1 ...)]
-      ;; dead gen elimination
-      [((~datum thread) _0 ... ((~datum gen) a ...) ((~datum gen) b ...) _1 ...)
-       #'(thread _0 ... (gen b ...) _1 ...)]
-      ;; prism identities
-      ;; Note: (~> ... △ ▽ ...) can't be rewritten to `values` since that's
-      ;; only valid if the input is in fact a list, and is an error otherwise,
-      ;; and we can only know this at runtime.
-      [((~datum thread) _0 ... (~datum collect) (~datum sep) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      ;; collapse `values` and `_` inside a threading form
-      [((~datum thread) _0 ... (~literal values) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      [((~datum thread) _0 ... (~datum _) _1 ...)
-       #'(thread _0 ... _1 ...)]
-      [((~datum #%blanket-template) (hex (~datum __)))
-       #'hex]
-      ;; return syntax unchanged if there are no applicable normalizations
-      [_ stx])))
+;; 0. "Qi-normal form"
+(define (normalize-rewrite stx)
+  (syntax-parse stx
+    ;; "deforestation" for values
+    ;; (~> (pass f) (>< g)) → (>< (if f g ⏚))
+    [((~datum thread) _0 ... ((~datum pass) f) ((~datum amp) g) _1 ...)
+     #'(thread _0 ... (amp (if f g ground)) _1 ...)]
+    ;; merge amps in sequence
+    [((~datum thread) _0 ... ((~datum amp) f) ((~datum amp) g) _1 ...)
+     #'(thread _0 ... (amp (thread f g)) _1 ...)]
+    ;; merge pass filters in sequence
+    [((~datum thread) _0 ... ((~datum pass) f) ((~datum pass) g) _1 ...)
+     #'(thread _0 ... (pass (and f g)) _1 ...)]
+    ;; collapse deterministic conditionals
+    [((~datum if) (~datum #t) f g) #'f]
+    [((~datum if) (~datum #f) f g) #'g]
+    ;; trivial threading form
+    [((~datum thread) f)
+     #'f]
+    ;; associative laws for ~>
+    [((~datum thread) _0 ... ((~datum thread) f ...) _1 ...) ; note: greedy matching
+     #'(thread _0 ... f ... _1 ...)]
+    ;; left and right identity for ~>
+    [((~datum thread) _0 ... (~datum _) _1 ...)
+     #'(thread _0 ... _1 ...)]
+    ;; composition of identity flows is the identity flow
+    [((~datum thread) (~datum _) ...)
+     #'_]
+    ;; identity flows composed using a relay
+    [((~datum relay) (~datum _) ...)
+     #'_]
+    ;; amp and identity
+    [((~datum amp) (~datum _))
+     #'_]
+    ;; trivial tee junction
+    [((~datum tee) f)
+     #'f]
+    ;; merge adjacent gens in a tee junction
+    [((~datum tee) _0 ... ((~datum gen) a ...) ((~datum gen) b ...) _1 ...)
+     #'(tee _0 ... (gen a ... b ...) _1 ...)]
+    ;; dead gen elimination
+    [((~datum thread) _0 ... ((~datum gen) a ...) ((~datum gen) b ...) _1 ...)
+     #'(thread _0 ... (gen b ...) _1 ...)]
+    ;; prism identities
+    ;; Note: (~> ... △ ▽ ...) can't be rewritten to `values` since that's
+    ;; only valid if the input is in fact a list, and is an error otherwise,
+    ;; and we can only know this at runtime.
+    [((~datum thread) _0 ... (~datum collect) (~datum sep) _1 ...)
+     #'(thread _0 ... _1 ...)]
+    ;; collapse `values` and `_` inside a threading form
+    [((~datum thread) _0 ... (~literal values) _1 ...)
+     #'(thread _0 ... _1 ...)]
+    [((~datum thread) _0 ... (~datum _) _1 ...)
+     #'(thread _0 ... _1 ...)]
+    [((~datum #%blanket-template) (hex (~datum __)))
+     #'hex]
+    ;; return syntax unchanged if there are no applicable normalizations
+    [_ stx]))

--- a/qi-lib/flow/core/util.rkt
+++ b/qi-lib/flow/core/util.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+
+(provide find-and-map/qi
+         fix)
+
+(require racket/match
+         syntax/parse)
+
+(define (find-and-map f stx)
+  ;; f : syntax? -> (or/c syntax? #f)
+  (match stx
+    [(? syntax?) (let ([stx^ (f stx)])
+                   (or stx^ (datum->syntax stx
+                              (find-and-map f (syntax-e stx))
+                              stx
+                              stx)))]
+    [(cons a d) (cons (find-and-map f a)
+                      (find-and-map f d))]
+    [_ stx]))
+
+(define (find-and-map/qi f stx)
+  ;; #%host-expression is a Racket macro defined by syntax-spec
+  ;; that resumes expansion of its sub-expression with an
+  ;; expander environment containing the original surface bindings
+  (find-and-map (syntax-parser [((~datum #%host-expression) e:expr) this-syntax]
+                               [_ (f this-syntax)])
+                stx))
+
+;; Applies f repeatedly to the init-val terminating the loop if the
+;; result of f is #f or the new syntax object is eq? to the previous
+;; (possibly initial) one.
+;;
+;; Caveats:
+;;   * the syntax object is not inspected, only eq? is used
+;;   * comparison is performed only between consecutive steps (does not handle cyclic occurences)
+(define ((fix f) init-val)
+  (let ([new-val (f init-val)])
+    (if (or (not new-val)
+            (eq? new-val init-val))
+        init-val
+        ((fix f) new-val))))

--- a/qi-test/tests/compiler.rkt
+++ b/qi-test/tests/compiler.rkt
@@ -5,14 +5,16 @@
 (require rackunit
          rackunit/text-ui
          (prefix-in semantics: "compiler/semantics.rkt")
-         (prefix-in rules: "compiler/rules.rkt"))
+         (prefix-in rules: "compiler/rules.rkt")
+         (prefix-in util: "compiler/util.rkt"))
 
 (define tests
   (test-suite
    "compiler tests"
 
    semantics:tests
-   rules:tests))
+   rules:tests
+   util:tests))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -2,12 +2,14 @@
 
 (provide tests)
 
-(require (for-template qi/flow/core/deforest
-                       qi/flow/core/compiler)
+(require (for-template qi/flow/core/compiler)
+         qi/flow/core/deforest
          rackunit
          rackunit/text-ui
          (only-in math sqr)
          racket/string
+         (only-in racket/list
+                  range)
          syntax/parse/define)
 
 (define-syntax-parse-rule (test-normalize msg a b ...+)

--- a/qi-test/tests/compiler/rules.rkt
+++ b/qi-test/tests/compiler/rules.rkt
@@ -8,9 +8,7 @@
          rackunit/text-ui
          (only-in math sqr)
          racket/string
-         syntax/parse
-         syntax/parse/define
-         (only-in racket/function curryr))
+         syntax/parse/define)
 
 (define-syntax-parse-rule (test-normalize msg a b ...+)
   (begin
@@ -27,15 +25,8 @@
 
 (define tests
   (test-suite
-   "compiler tests"
+   "Compiler rule tests"
 
-   (test-suite
-    "fixed point"
-    (check-equal? ((fix abs) -1) 1)
-    (check-equal? ((fix abs) -1) 1)
-    (let ([integer-div2 (compose floor (curryr / 2))])
-      (check-equal? ((fix integer-div2) 10)
-                    0)))
    (test-suite
     "deforestation"
     ;; Note that these test deforestation in isolation

--- a/qi-test/tests/compiler/util.rkt
+++ b/qi-test/tests/compiler/util.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(provide tests)
+
+(require qi/flow/core/util
+         rackunit
+         rackunit/text-ui
+         (only-in racket/function
+                  curryr))
+
+(define tests
+  (test-suite
+   "Compiler utilities tests"
+
+   (test-suite
+    "fixed point"
+    (check-equal? ((fix abs) -1) 1)
+    (check-equal? ((fix abs) -1) 1)
+    (let ([integer-div2 (compose floor (curryr / 2))])
+      (check-equal? ((fix integer-div2) 10)
+                    0)))))
+
+(module+ main
+  (void (run-tests tests)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -436,6 +436,10 @@
     "routing forms"
     (test-suite
      "~>"
+     (test-equal? "basic threading"
+                  ((☯ (~> sqr add1))
+                   3)
+                  10)
      (check-equal? ((☯ (~> add1
                            (* 2)
                            number->string


### PR DESCRIPTION
### Summary of Changes

Some follow-up work from last week's meeting. Also, in some modules we had everything required and provided `for-syntax` and everything defined `begin-for-syntax` and then required without modulating the phase, i.e. just as `(require module)`. Assuming it is equivalent to define everything at phase 0 and then modulate the phase at `require` time, this should be simpler and make these modules easier to reason about.

So far I haven't succeeded at doing the same thing for the `compiler.rkt` module which also has most of its code in the syntax phase...

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
