### PR TITLE
Bind and switch (and other improvements)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ help:
 	@echo "  definitions"
 	@echo "  macro"
 	@echo "  util"
+	@echo "  expander"
+	@echo "  compiler"
 	@echo "  probe"
 	@echo "    Note: As probe is not in qi-lib, it isn't part of"
 	@echo "    the tests run in the 'test' target."
@@ -124,6 +126,9 @@ test-macro:
 test-util:
 	racket -y $(PACKAGE-NAME)-test/tests/util.rkt
 
+test-expander:
+	racket -y $(PACKAGE-NAME)-test/tests/expander.rkt
+
 test-compiler:
 	racket -y $(PACKAGE-NAME)-test/tests/compiler.rkt
 
@@ -196,4 +201,4 @@ performance-report:
 performance-regression-report:
 	@racket $(PACKAGE-NAME)-sdk/profile/report.rkt -r $(REF)
 
-.PHONY:	help install remove build build-docs build-all clean check-deps test test-flow test-on test-threading test-switch test-definitions test-macro test-util test-compiler test-probe test-with-errortrace errortrace errortrace-flow errortrace-on errortrace-threading errortrace-switch errortrace-definitions errortrace-macro errortrace-util errortrace-probe docs cover coverage-check coverage-report cover-coveralls profile-local profile-loading profile-selected-forms profile-competitive profile-nonlocal profile performance-report performance-regression-report
+.PHONY:	help install remove build build-docs build-all clean check-deps test test-flow test-on test-threading test-switch test-definitions test-macro test-util test-expander test-compiler test-probe test-with-errortrace errortrace errortrace-flow errortrace-on errortrace-threading errortrace-switch errortrace-definitions errortrace-macro errortrace-util errortrace-probe docs cover coverage-check coverage-report cover-coveralls profile-local profile-loading profile-selected-forms profile-competitive profile-nonlocal profile performance-report performance-regression-report

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -13,6 +13,7 @@
          "flow/extended/expander.rkt"
          "flow/core/compiler.rkt"
          "flow/extended/forms.rkt"
+         (for-syntax "flow/extended/util.rkt")
          (only-in "private/util.rkt"
                   define-alias))
 
@@ -43,6 +44,8 @@ in the flow macro.
       [(expr0 expr ...+)
        (report-syntax-error
            (datum->syntax this-syntax
-             (cons 'flow (syntax->list this-syntax)))
+             (cons 'flow
+                   (map prettify-flow-syntax
+                        (syntax->list this-syntax))))
          "(flow flo)"
          "flow expects a single flow specification, but it received many.")])))

--- a/qi-lib/flow/core/compiler.rkt
+++ b/qi-lib/flow/core/compiler.rkt
@@ -33,7 +33,7 @@
     ;; Note: deforestation happens only for threading,
     ;; and the normalize pass strips the threading form
     ;; if it contains only one expression, so this would not be hit.
-    (find-and-map/qi (fix deforest-rewrite)
+    (find-and-map/qi deforest-rewrite
                      stx))
 
   (define-qi-expansion-step (~deforest-pass stx)

--- a/qi-lib/flow/core/deforest.rkt
+++ b/qi-lib/flow/core/deforest.rkt
@@ -4,7 +4,8 @@
 
 (require (for-syntax racket/base
                      syntax/parse
-                     racket/syntax-srcloc)
+                     racket/syntax-srcloc
+                     "../extended/util.rkt")
          racket/performance-hint
          racket/match
          racket/list
@@ -26,21 +27,6 @@
     [(_ [op f] rest ...) (op f (inline-compose1 rest ...))]))
 
 (begin-for-syntax
-  ;; Partially reconstructs original flow expressions. The chirality
-  ;; is lost and the form is already normalized at this point though!
-  (define (prettify-flow-syntax stx)
-    (syntax-parse stx
-      #:datum-literals (#%host-expression esc #%blanket-template #%fine-template)
-      [((~literal thread)
-        expr ...)
-       #`(~> #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
-      [((~or #%blanket-template #%fine-template)
-        (expr ...))
-       (map prettify-flow-syntax (syntax->list #'(expr ...)))]
-      [(#%host-expression expr) #'expr]
-      [(esc expr) (prettify-flow-syntax #'expr)]
-      [expr #'expr]))
-
   ;; Special "curry"ing for #%fine-templates. All #%host-expressions
   ;; are passed as they are and all (~datum _) are replaced by wrapper
   ;; lambda arguments.

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -105,9 +105,10 @@
                "(group <number> <selection flow> <remainder flow>)"))
     (if consequent:closed-floe
         alternative:closed-floe)
-    (if condition:closed-floe
+    (if condition:floe
         consequent:closed-floe
         alternative:closed-floe)
+    #:binding (nest-one condition [consequent alternative])
     (sieve condition:closed-floe
            sonex:closed-floe
            ronex:closed-floe)

--- a/qi-lib/flow/extended/syntax.rkt
+++ b/qi-lib/flow/extended/syntax.rkt
@@ -7,7 +7,7 @@
          fine-template-form
          partial-application-form
          any-stx
-         ;; only used for unit tests
+         ;; only provided for use in unit tests
          make-right-chiral)
 
 (require syntax/parse

--- a/qi-lib/flow/extended/syntax.rkt
+++ b/qi-lib/flow/extended/syntax.rkt
@@ -6,7 +6,9 @@
          blanket-template-form
          fine-template-form
          partial-application-form
-         any-stx)
+         any-stx
+         ;; only used for unit tests
+         make-right-chiral)
 
 (require syntax/parse
          "../aux-syntax.rkt"

--- a/qi-lib/flow/extended/util.rkt
+++ b/qi-lib/flow/extended/util.rkt
@@ -15,7 +15,27 @@
                       thread
                       amp
                       tee
-                      relay)
+                      relay
+                      gen
+                      pass
+                      sep
+                      and
+                      or
+                      not
+                      all
+                      any
+                      fanout
+                      group
+                      if
+                      sieve
+                      partition
+                      try
+                      >>
+                      <<
+                      feedback
+                      loop
+                      loop2
+                      clos)
     [(thread
       expr ...)
      #`(~> #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
@@ -23,14 +43,79 @@
       (expr ...))
      (map prettify-flow-syntax (syntax->list #'(expr ...)))]
     [(#%host-expression expr) #'expr]
-    [((~datum amp)
+    [(amp
       expr ...)
      #`(>< #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
-    [((~datum tee)
+    [(tee
       expr ...)
      #`(-< #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
-    [((~datum relay)
+    [(relay
       expr ...)
      #`(== #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(gen
+      expr ...)
+     #`(gen #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(pass
+      expr ...)
+     #`(pass #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(sep
+      expr ...)
+     #`(sep #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(and
+      expr ...)
+     #`(and #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(or
+      expr ...)
+     #`(or #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(not
+      expr ...)
+     #`(not #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(all
+      expr ...)
+     #`(all #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(any
+      expr ...)
+     #`(any #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(fanout
+      expr ...)
+     #`(fanout #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(group
+      expr ...)
+     #`(group #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(if
+      expr ...)
+     #`(if #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(sieve
+      expr ...)
+     #`(sieve #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(partition
+      [e1 e2] ...)
+     #:with e1-prettified (map prettify-flow-syntax (attribute e1))
+     #:with e2-prettified (map prettify-flow-syntax (attribute e2))
+     #`(partition [e1-prettified e2-prettified])]
+    [(try expr
+      [e1 e2] ...)
+     #:with expr-prettified (prettify-flow-syntax #'expr)
+     #:with e1-prettified (map prettify-flow-syntax (attribute e1))
+     #:with e2-prettified (map prettify-flow-syntax (attribute e2))
+     #`(try expr-prettified [e1-prettified e2-prettified])]
+    [(>>
+      expr ...)
+     #`(>> #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(<<
+      expr ...)
+     #`(<< #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(feedback
+      expr ...)
+     #`(feedback #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(loop
+      expr ...)
+     #`(loop #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(loop2
+      expr ...)
+     #`(loop2 #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(clos
+      expr ...)
+     #`(clos #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
     [(esc expr) (prettify-flow-syntax #'expr)]
     [expr #'expr]))

--- a/qi-lib/flow/extended/util.rkt
+++ b/qi-lib/flow/extended/util.rkt
@@ -1,0 +1,36 @@
+#lang racket/base
+
+(provide prettify-flow-syntax)
+
+(require syntax/parse)
+
+;; Partially reconstructs original flow expressions. The chirality
+;; is lost and the form is already normalized at this point though!
+(define (prettify-flow-syntax stx)
+  (syntax-parse stx
+    #:datum-literals (#%host-expression
+                      esc
+                      #%blanket-template
+                      #%fine-template
+                      thread
+                      amp
+                      tee
+                      relay)
+    [(thread
+      expr ...)
+     #`(~> #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [((~or #%blanket-template #%fine-template)
+      (expr ...))
+     (map prettify-flow-syntax (syntax->list #'(expr ...)))]
+    [(#%host-expression expr) #'expr]
+    [((~datum amp)
+      expr ...)
+     #`(>< #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [((~datum tee)
+      expr ...)
+     #`(-< #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [((~datum relay)
+      expr ...)
+     #`(== #,@(map prettify-flow-syntax (syntax->list #'(expr ...))))]
+    [(esc expr) (prettify-flow-syntax #'expr)]
+    [expr #'expr]))

--- a/qi-test/info.rkt
+++ b/qi-test/info.rkt
@@ -6,5 +6,6 @@
 (define build-deps '("rackunit-lib"
                      "adjutor"
                      "math-lib"
-                     "qi-lib"))
+                     "qi-lib"
+                     "syntax-spec-v1"))
 (define clean '("compiled" "tests/compiled" "tests/private/compiled"))

--- a/qi-test/tests/expander.rkt
+++ b/qi-test/tests/expander.rkt
@@ -2,7 +2,8 @@
 
 (provide tests)
 
-(require (for-syntax racket/base)
+(require (for-syntax racket/base
+                     qi/flow/extended/syntax)
          syntax/macro-testing
          syntax-spec-v1
          racket/base
@@ -25,12 +26,77 @@
   (test-suite
    "expander tests"
 
-   (check-true
-    (phase1-eval
-     (equal? (syntax->datum
-              (expand-flow #'(~> sqr add1)))
-             '(thread (esc (#%host-expression sqr))
-                      (esc (#%host-expression add1))))))))
+   (test-true "basic expansion"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'(~> sqr add1)))
+                       '(thread (esc (#%host-expression sqr))
+                                (esc (#%host-expression add1))))))
+
+   (test-true "single core form (if)"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'(if p c a)))
+                       '(if (esc (#%host-expression p))
+                            (esc (#%host-expression c))
+                            (esc (#%host-expression a))))))
+
+   (test-true "mix of core forms"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'(thread (amp a)
+                                               (relay b c)
+                                               (tee d e))))
+                       '(thread
+                         (amp (esc (#%host-expression a)))
+                         (relay (esc (#%host-expression b)) (esc (#%host-expression c)))
+                         (tee (esc (#%host-expression d)) (esc (#%host-expression e)))))))
+
+   (test-true "undecorated functions are escaped"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'f))
+                       '(esc (#%host-expression f)))))
+
+   (test-true "literal is expanded to an explicit use of the gen core form"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'5))
+                       '(gen (#%host-expression 5)))))
+
+   (test-true "fine template syntax expands to an explicit use of the #%fine-template core form"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'(f _ a _ b)))
+                       '(#%fine-template
+                         ((#%host-expression f)
+                          _
+                          (#%host-expression a)
+                          _
+                          (#%host-expression b))))))
+
+   (test-true "blanket template syntax expands to an explicit use of the #%blanket-template core form"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow #'(f a __ b)))
+                       '(#%blanket-template
+                         ((#%host-expression f)
+                          (#%host-expression a)
+                          __
+                          (#%host-expression b))))))
+
+   (test-true "expand chiral forms to a use of a blanket template"
+              (phase1-eval
+               (equal? (syntax->datum
+                        (expand-flow
+                         (datum->syntax #f
+                           (map make-right-chiral
+                                (syntax->list
+                                 #'(thread (f 1)))))))
+                       '(thread (#%blanket-template
+                                 ((#%host-expression f)
+                                  (#%host-expression 1)
+                                  __))))))))
 
 (module+ main
   (void

--- a/qi-test/tests/expander.rkt
+++ b/qi-test/tests/expander.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+
+(provide tests)
+
+(require (for-syntax racket/base)
+         syntax/macro-testing
+         syntax-spec-v1
+         racket/base
+         qi/flow/extended/expander
+         rackunit
+         rackunit/text-ui)
+
+(begin-for-syntax
+  (define (expand-flow stx)
+    ((nonterminal-expander closed-floe) stx)))
+
+;; TODO: these tests compare syntax as datums, but that's not sufficient
+;; since the identifiers used may be bound differently which would affect
+;; e.g. literal pattern matching.
+;; To do it correctly, we need an alpha-equivalence predicate for Core Qi
+;; that possibly delegates to a similar predicate for any Racket
+;; subexpressions. This could be a predicate that syntax-spec could
+;; infer, but it's unclear at this time.
+(define tests
+  (test-suite
+   "expander tests"
+
+   (check-true
+    (phase1-eval
+     (equal? (syntax->datum
+              (expand-flow #'(~> sqr add1)))
+             '(thread (esc (#%host-expression sqr))
+                      (esc (#%host-expression add1))))))))
+
+(module+ main
+  (void
+   (run-tests tests)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -419,6 +419,27 @@
                                    (as v))))
                         3)))
                "tee junction tines don't bind preceding peers")
+    (check-equal? ((☯ (switch [(~> sqr (ε (as v) #t))
+                               (gen v)]))
+                   3)
+                  9
+                  "switch conditions bind clauses")
+    (check-equal? ((☯ (switch
+                        [(~> sqr (ε (as v) #f))
+                         (gen v)]
+                        [(~> add1 (ε (as v) #t))
+                         (gen v)]))
+                   3)
+                  4
+                  "bindings in switch conditions shadow earlier conditions")
+    (check-exn exn:fail?
+               (thunk
+                (convert-compile-time-error
+                 ((☯ (~> (switch [(~> sqr (ε (as v) #t))
+                                  0])
+                         (gen v)))
+                  3)))
+               "switch does not bind downstream")
     (check-exn exn:fail?
                (thunk (convert-compile-time-error
                        ((☯ (~> (or (ε (as v)) 5) (+ v)))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -354,10 +354,19 @@
     (check-equal? ((☯ (~> (as v) (+ v))) 3)
                   3
                   "binds a single value")
+    (check-equal? ((☯ (~> (as v w) (+ v w))) 3 4)
+                  7
+                  "binds multiple values")
+    (check-false ((☯ (~> (as v) live?)) 3)
+                 "binding does not propagate the value")
     (check-equal? ((☯ (~> (-< (as v)
                               _) (+ 3 _ v))) 3)
                   9
                   "reference in a fine template")
+    (check-equal? ((☯ (~> (-< (as v)
+                              _) (+ 3 __ v))) 3)
+                  9
+                  "reference in a blanket template")
     (check-equal? ((☯ (~> (-< (as v)
                               _) (+ 3 v))) 3)
                   9
@@ -366,15 +375,6 @@
                                _) (+ 3 v))) 3)
                   9
                   "reference in a right-chiral partial application")
-    (check-equal? ((☯ (~> (-< (as v)
-                              _) (+ 3 __ v))) 3)
-                  9
-                  "reference in a blanket template")
-    (check-false ((☯ (~> (as v) live?)) 3)
-                 "binding does not propagate the value")
-    (check-equal? ((☯ (~> (as v w) (+ v w))) 3 4)
-                  7
-                  "binds multiple values")
     (check-equal? ((☯ (~> (-< (~> list (as vs))
                               +)
                           (~a "The sum of " vs " is " _)))

--- a/qi-test/tests/qi.rkt
+++ b/qi-test/tests/qi.rkt
@@ -9,6 +9,7 @@
          (prefix-in definitions: "definitions.rkt")
          (prefix-in macro: "macro.rkt")
          (prefix-in util: "util.rkt")
+         (prefix-in expander: "expander.rkt")
          (prefix-in compiler: "compiler.rkt"))
 
 (define tests
@@ -22,6 +23,7 @@
    definitions:tests
    macro:tests
    util:tests
+   expander:tests
    compiler:tests))
 
 (module+ test


### PR DESCRIPTION
### Summary of Changes

This is our WIP from the most recent Qi meeting, including:

- a binding specification for `if` (and therefore `switch`) that allows conditions to bind clauses (see: [the ol' bind and switch](https://github.com/drym-org/qi/wiki/Qi-Compiler-Sync-Dec-1-2023#the-ol-bind-and-switch))
- remove fixed-point finding in deforestation pass as a single pass is sufficient
- more unit tests for bindings
- starter tests for the expander
- use the de-expander to improve more error messages

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
