### PR TITLE
Fix weird syntax pair bug

### DIFF
--- a/qi-lib/flow/core/util.rkt
+++ b/qi-lib/flow/core/util.rkt
@@ -6,6 +6,10 @@
 (require racket/match
          syntax/parse)
 
+(define (form-position? v)
+  (and (syntax? v)
+       (syntax-property v 'nonterminal)))
+
 ;; Walk the syntax tree in a "top down" manner, i.e. from the root down
 ;; to the leaves, applying a transformation to each node.
 ;; The transforming function is expected to either return transformed
@@ -25,8 +29,7 @@
                            ;; no transformation was applied, so
                            ;; keep traversing
                            (datum->syntax stx
-                             (find-and-map f (or (syntax->list stx)
-                                                 (syntax-e stx)))
+                             (find-and-map f (syntax-e stx))
                              stx
                              stx)
                            ;; transformation was applied, so we stop
@@ -43,8 +46,15 @@
   ;; #%host-expression is a Racket macro defined by syntax-spec
   ;; that resumes expansion of its sub-expression with an
   ;; expander environment containing the original surface bindings
+  ;; TODO: technically should be ~literal host expression to not
+  ;; collide with a user-defined #%host-expression binding, but that
+  ;; would never be hit in practice since that would be rewritten
+  ;; through expansion to a use of the core language. In general,
+  ;; we should be using ~literal matching throughout the compiler.
   (find-and-map (syntax-parser [((~datum #%host-expression) e:expr) #f]
-                               [_ (f this-syntax)])
+                               [_ (if (form-position? this-syntax)
+                                      (f this-syntax)
+                                      this-syntax)])
                 stx))
 
 ;; Applies f repeatedly to the init-val terminating the loop if the

--- a/qi-lib/flow/core/util.rkt
+++ b/qi-lib/flow/core/util.rkt
@@ -25,7 +25,8 @@
                            ;; no transformation was applied, so
                            ;; keep traversing
                            (datum->syntax stx
-                             (find-and-map f (syntax-e stx))
+                             (find-and-map f (or (syntax->list stx)
+                                                 (syntax-e stx)))
                              stx
                              stx)
                            ;; transformation was applied, so we stop

--- a/qi-test/tests/compiler/util.rkt
+++ b/qi-test/tests/compiler/util.rkt
@@ -24,9 +24,8 @@
 (define (tree-map f tree)
   (cond [(list? tree) (map (curry tree-map f)
                            tree)]
-        [(syntax-list? tree) (datum->syntax tree
-                               (map (curry tree-map f)
-                                    (syntax->list tree)))]
+        [(syntax-list? tree) (f (datum->syntax tree
+                                  (tree-map f (syntax->list tree))))]
         [else (f tree)]))
 
 (define (attach-form-property stx)
@@ -83,7 +82,7 @@
                         #'(a c d)
                         #'(a c d))
     ;; TODO: review this, it does not transform multi-level matches.
-    ;; Are there cases where we would need this?
+    ;; See a TODO in tests/compiler/rules.rkt for a case where we would need it
     (test-syntax-equal? "matches at multiple levels"
                         (syntax-parser [((~datum a) b ...) #'(b ...)]
                                        [_ this-syntax])

--- a/qi-test/tests/compiler/util.rkt
+++ b/qi-test/tests/compiler/util.rkt
@@ -6,7 +6,9 @@
          rackunit
          rackunit/text-ui
          syntax/parse
+         syntax/parse/define
          syntax/parse/experimental/template
+         (for-syntax racket/base)
          (only-in "../private/util.rkt" tag-syntax)
          (only-in racket/function
                   curry
@@ -16,11 +18,15 @@
 ;; NOTE: we need to tag test syntax with `tag-syntax`
 ;; in most cases. See the comment on that function definition.
 
-(define-syntax-rule (test-syntax-equal? name f a b)
-  (test-equal? name
-               (syntax->datum
-                (find-and-map/qi f (tag-syntax a)))
-               (syntax->datum b)))
+;; traverse syntax a and map it under the indicated parser patterns
+;; using find-and-map/qi, and verify it results in syntax b
+(define-syntax-parser test-syntax-map-equal?
+  [(_ name (pat ...) a b)
+   #:with f #'(syntax-parser pat ...)
+   #'(test-equal? name
+                  (syntax->datum
+                   (find-and-map/qi f (tag-syntax a)))
+                  (syntax->datum b))])
 
 (define tests
   (test-suite
@@ -38,59 +44,59 @@
                   "false return value terminates fixed-point finding"))
    (test-suite
     "find-and-map/qi"
-    (test-syntax-equal? "top level"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a b c)
-                        #'(a q c))
-    (test-syntax-equal? "does not explore node on false return value"
-                        (syntax-parser [((~datum stop) e ...) #f]
-                                       [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a b (stop c b))
-                        #'(a q (stop c b)))
-    (test-syntax-equal? "nested"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a (b c) d)
-                        #'(a (q c) d))
-    (test-syntax-equal? "multiple matches"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a b c b d)
-                        #'(a q c q d))
-    (test-syntax-equal? "multiple nested matches"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a (b c) (b d))
-                        #'(a (q c) (q d)))
-    (test-syntax-equal? "no match"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a c d)
-                        #'(a c d))
+    (test-syntax-map-equal? "top level"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a b c)
+                            #'(a q c))
+    (test-syntax-map-equal? "does not explore node on false return value"
+                            ([((~datum stop) e ...) #f]
+                             [(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a b (stop c b))
+                            #'(a q (stop c b)))
+    (test-syntax-map-equal? "nested"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a (b c) d)
+                            #'(a (q c) d))
+    (test-syntax-map-equal? "multiple matches"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a b c b d)
+                            #'(a q c q d))
+    (test-syntax-map-equal? "multiple nested matches"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a (b c) (b d))
+                            #'(a (q c) (q d)))
+    (test-syntax-map-equal? "no match"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a c d)
+                            #'(a c d))
     ;; TODO: review this, it does not transform multi-level matches.
     ;; See a TODO in tests/compiler/rules.rkt for a case where we would need it
-    (test-syntax-equal? "matches at multiple levels"
-                        (syntax-parser [((~datum a) b ...) #'(b ...)]
-                                       [_ this-syntax])
-                        #'(a c (a d e))
-                        #'(c (a d e)))
-    (test-syntax-equal? "does not match spliced"
-                        (syntax-parser [((~datum a) b ...) #'(b ...)]
-                                       [_ this-syntax])
-                        #'(c a b d e)
-                        #'(c a b d e))
-    (test-syntax-equal? "does not enter host expressions"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(a (#%host-expression (b c)) d)
-                        #'(a (#%host-expression (b c)) d))
-    (test-syntax-equal? "toplevel host expression"
-                        (syntax-parser [(~datum b) #'q]
-                                       [_ this-syntax])
-                        #'(#%host-expression (b c))
-                        #'(#%host-expression (b c))))))
+    (test-syntax-map-equal? "matches at multiple levels"
+                            ([((~datum a) b ...) #'(b ...)]
+                             [_ this-syntax])
+                            #'(a c (a d e))
+                            #'(c (a d e)))
+    (test-syntax-map-equal? "does not match spliced"
+                            ([((~datum a) b ...) #'(b ...)]
+                             [_ this-syntax])
+                            #'(c a b d e)
+                            #'(c a b d e))
+    (test-syntax-map-equal? "does not enter host expressions"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(a (#%host-expression (b c)) d)
+                            #'(a (#%host-expression (b c)) d))
+    (test-syntax-map-equal? "toplevel host expression"
+                            ([(~datum b) #'q]
+                             [_ this-syntax])
+                            #'(#%host-expression (b c))
+                            #'(#%host-expression (b c))))))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/util.rkt
+++ b/qi-test/tests/compiler/util.rkt
@@ -7,32 +7,20 @@
          rackunit/text-ui
          syntax/parse
          syntax/parse/experimental/template
+         (only-in "../private/util.rkt" tag-syntax)
          (only-in racket/function
                   curry
                   curryr
                   thunk*))
+
+;; NOTE: we need to tag test syntax with `tag-syntax`
+;; in most cases. See the comment on that function definition.
 
 (define-syntax-rule (test-syntax-equal? name f a b)
   (test-equal? name
                (syntax->datum
                 (find-and-map/qi f (tag-syntax a)))
                (syntax->datum b)))
-
-(define (syntax-list? v)
-  (and (syntax? v) (syntax->list v)))
-
-(define (tree-map f tree)
-  (cond [(list? tree) (map (curry tree-map f)
-                           tree)]
-        [(syntax-list? tree) (f (datum->syntax tree
-                                  (tree-map f (syntax->list tree))))]
-        [else (f tree)]))
-
-(define (attach-form-property stx)
-  (syntax-property stx 'nonterminal 'floe))
-
-(define (tag-syntax stx)
-  (tree-map attach-form-property stx))
 
 (define tests
   (test-suite

--- a/qi-test/tests/compiler/util.rkt
+++ b/qi-test/tests/compiler/util.rkt
@@ -6,6 +6,7 @@
          rackunit
          rackunit/text-ui
          syntax/parse
+         syntax/parse/experimental/template
          (only-in racket/function
                   curryr
                   thunk*))
@@ -14,6 +15,10 @@
   (test-equal? name
                (syntax->datum a)
                (syntax->datum b)))
+
+(define-template-metafunction qi-form
+  (syntax-parser
+    [(_ e) (syntax-property #'e 'nonterminal 'floe)]))
 
 (define tests
   (test-suite
@@ -35,7 +40,7 @@
                         (find-and-map/qi
                          (syntax-parser [(~datum b) #'q]
                                         [_ this-syntax])
-                         #'(a b c))
+                         #'(qi-form (a (qi-form b) c)))
                         #'(a q c))
     (test-syntax-equal? "does not explore node on false return value"
                         (find-and-map/qi

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -1070,7 +1070,11 @@
                                          [#f list]) collect))
                     -1 2 1 1 -2 2)
                    (list null null)
-                   "no match in any clause"))
+                   "no match in any clause")
+     (check-not-exn (thunk
+                     (convert-compile-time-error
+                      (☯ (partition [-< ▽]))))
+                    "no improper optimization"))
     (test-suite
      "gate"
      (check-equal? ((☯ (gate positive?))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -1074,7 +1074,7 @@
      (check-not-exn (thunk
                      (convert-compile-time-error
                       (☯ (partition [-< ▽]))))
-                    "no improper optimization"))
+                    "no improper optimization of subforms resembling use of core syntax"))
     (test-suite
      "gate"
      (check-equal? ((☯ (gate positive?))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -563,9 +563,9 @@
                    "a"))
     (test-suite
      "-<"
-     ;; (check-equal? ((☯ (~> -< ▽))
-     ;;                3 1 2)
-     ;;               (list 1 2 1 2 1 2))
+     (check-equal? ((☯ (~> -< ▽))
+                    3 1 2)
+                   (list 1 2 1 2 1 2))
      (check-equal? ((☯ (~> (-< sqr add1) ▽))
                     5)
                    (list 25 6))

--- a/qi-test/tests/private/util.rkt
+++ b/qi-test/tests/private/util.rkt
@@ -8,6 +8,7 @@
          my-or
          also-or
          also-and
+         tag-syntax
          (for-space qi
                     also-and
                     double-me
@@ -54,3 +55,33 @@
 (define-qi-foreign-syntaxes double-me)
 
 (define-qi-foreign-syntaxes add-two)
+
+(define (syntax-list? v)
+  (and (syntax? v) (syntax->list v)))
+
+(define (tree-map f tree)
+  (cond [(list? tree) (map (curry tree-map f)
+                           tree)]
+        [(syntax-list? tree) (f (datum->syntax tree
+                                  (tree-map f (syntax->list tree))))]
+        [else (f tree)]))
+
+(define (attach-form-property stx)
+  (syntax-property stx 'nonterminal 'floe))
+
+;; In traversing Qi syntax to apply optimization rules in the compiler,
+;; we only want to apply such rules to syntax that is a legitimate use of
+;; a core Qi form. A naive tree traversal may in some cases yield
+;; subexpressions that aren't valid Qi syntax on their own, and we
+;; need a way to a avoid attempting to optimize these. The "right way"
+;; remains to be defined (e.g. either we do a tree traversal that is
+;; not naive and is aware of the core language grammar, or Syntax Spec
+;; provides such a traversal utility inferred from the core language grammar
+;; (for use by any language), or something else. But for now, Syntax Spec
+;; helps us out by attaching a syntax property to each such legitimate use
+;; of core language syntax, and we look for that during tree traversal
+;; (i.e. in `find-and-map`), only optimizing if it is present. In order
+;; to test rewrite rules, we need to attach such a property too, in syntax
+;; that we use in testing, and that's what this utility does.
+(define (tag-syntax stx)
+  (tree-map attach-form-property stx))


### PR DESCRIPTION
### Summary of Changes

This fixes the [weird syntax pair bug](https://github.com/drym-org/qi/pull/86#issuecomment-1865385421), ~but we don't really understand why it happens this way~.

The reason it was happening is that `syntax-e` is apparently not guaranteed to produce a list even if the input happens to be a syntax list. Since Qi has some core syntax that can be used in identifier form, that meant that expansion was producing a syntax pair here rather than a syntax list (for reasons that should be considered internal implementation details that we should not rely on due to syntax-e making no promises regarding producing a syntax list).

So instead of doing a naive tree traversal where we attempt to optimize every syntax component, we had a couple of more robust options to consider:

1. Do a proper tree traversal that is aware of Qi core language syntax and only attempts to apply the transforming function to well-formed uses (rather than partial subsets) of this syntax.
2. Add a generic utilility in Syntax Spec that would provide such a traversal to any language by inferring it from the core language grammar

We went with a third, short-term option, for Syntax Spec to attach a syntax property indicating that syntax is or isn't a full and well-formed use of core language syntax. And then in our naive traversal, we look for this property and only attempt to optimize if it's present.

(this is WIP from today's meeting)

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
