### PR TITLE
Regression test for sandboxed evaluation

### DIFF
--- a/qi-lib/flow/core/passes.rkt
+++ b/qi-lib/flow/core/passes.rkt
@@ -6,7 +6,10 @@
 (provide (for-syntax define-and-register-pass
                      run-passes))
 
-(begin-for-syntax
+(module macro-debug racket/base
+  ;; See tests/compiler/rules/full-cycle.rkt for an explanation
+  ;; re: sandboxed evaluation, submodules and test coverage.
+  (provide my-emit-local-step)
 
   (define my-emit-local-step
     ;; See "Breaking Out of the Sandbox"
@@ -15,7 +18,11 @@
                             (make-keyword-procedure
                              (lambda (kws kw-args . rest)
                                (void))))))
-      (dynamic-require 'macro-debugger/emit 'emit-local-step)))
+      (dynamic-require 'macro-debugger/emit 'emit-local-step))))
+
+(require (for-syntax 'macro-debug))
+
+(begin-for-syntax
 
   ;; Could be a list but for future extensibility a custom struct is
   ;; probably a better idea.

--- a/qi-lib/flow/extended/forms.rkt
+++ b/qi-lib/flow/extended/forms.rkt
@@ -15,7 +15,8 @@
          syntax/parse/define
          "expander.rkt"
          "../../macro.rkt"
-         "../space.rkt"
+         (only-in "../space.rkt"
+                  define-for-qi)
          "impl.rkt")
 
 ;;; Predicates

--- a/qi-test/info.rkt
+++ b/qi-test/info.rkt
@@ -6,5 +6,6 @@
 (define build-deps '("rackunit-lib"
                      "adjutor"
                      "math-lib"
+                     "sandbox-lib"
                      "qi-lib"))
 (define clean '("compiled" "tests/compiled" "tests/private/compiled"))

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -21,15 +21,6 @@
            (for-template qi/flow/core/compiler)
            (for-syntax racket/base))
 
-  ;; A macro that accepts surface syntax, expands it, and then applies the
-  ;; indicated optimization passes.
-  (define-syntax-parser test-passes~>
-    [(_ stx)
-     #'(expand-flow stx)]
-    [(_ stx pass ... passN)
-     #'(passN
-        (test-passes~> stx pass ...))])
-
   ;; A macro that expands and compiles surface syntax
   (define-syntax-parse-rule (qi-compile stx)
     (compile-flow

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -21,8 +21,8 @@
            (for-template qi/flow/core/compiler)
            (for-syntax racket/base))
 
-  ;; A macro that expands and compiles surface syntax
-  (define-syntax-parse-rule (qi-compile stx)
+  ;; A function that expands and compiles surface syntax
+  (define (qi-compile stx)
     (compile-flow
      (expand-flow stx))))
 

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -11,6 +11,7 @@
          rackunit/text-ui
          syntax/macro-testing
          qi/flow/core/deforest
+         qi/flow/core/compiler
          "private/deforest-util.rkt"
          (submod qi/flow/extended/expander invoke))
 
@@ -21,12 +22,17 @@
 
   ;; A macro that accepts surface syntax, expands it, and then applies the
   ;; indicated optimization passes.
-  (define-syntax-parser test-compile~>
+  (define-syntax-parser test-passes~>
     [(_ stx)
      #'(expand-flow stx)]
     [(_ stx pass ... passN)
      #'(passN
-        (test-compile~> stx pass ...))]))
+        (test-passes~> stx pass ...))])
+
+  ;; A macro that expands and compiles surface syntax
+  (define-syntax-parse-rule (qi-compile stx)
+    (compile-flow
+     (expand-flow stx))))
 
 
 (define tests
@@ -39,9 +45,8 @@
     (test-true "normalize → deforest"
                (deforested?
                  (phase1-eval
-                  (test-compile~> #'(~>> (filter odd?) values (map sqr))
-                                  normalize-pass
-                                  deforest-pass)))))))
+                  (qi-compile
+                   #'(~>> (filter odd?) values (map sqr)))))))))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -59,34 +59,11 @@
                   ;; We address this by putting `my-emit-local-step` in a
                   ;; submodule, which, by default, are ignored by coverage.
                   (lambda ()
-                    (let ([eval (parameterize ([sandbox-output 'string]
-                                               [sandbox-error-output 'string]
-                                               [sandbox-memory-limit #f])
-                                  (make-evaluator
-                                   'racket/base
-                                   '(require (for-syntax racket/base)
-                                             ;; necessary to recognize and expand core forms correctly
-                                             qi/flow/extended/expander
-                                             ;; necessary to correctly expand the right-threading form
-                                             qi/flow/extended/forms
-                                             syntax/macro-testing
-                                             racket/list
-                                             qi/flow/core/compiler
-                                             (submod qi/flow/extended/expander invoke))
-
-                                   '(begin-for-syntax
-                                      (require syntax/parse/define
-                                               (for-template qi/flow/core/compiler)
-                                               (for-syntax racket/base))
-
-                                      ;; A macro that expands and compiles surface syntax
-                                      (define-syntax-parse-rule (qi-compile stx)
-                                        (compile-flow
-                                         (expand-flow stx))))))])
+                    (let ([eval (make-evaluator
+                                 'racket/base
+                                 '(require qi))])
                       (eval
-                       '(phase1-eval
-                         (qi-compile
-                          #'sqr)))))))))
+                       '(~> (3) (* 2) add1))))))))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -12,7 +12,6 @@
          syntax/macro-testing
          qi/flow/core/deforest
          qi/flow/core/compiler
-         racket/sandbox
          "private/deforest-util.rkt"
          (submod qi/flow/extended/expander invoke))
 
@@ -34,23 +33,7 @@
                (deforested?
                  (phase1-eval
                   (qi-compile
-                   #'(~>> (filter odd?) values (map sqr)))))))
-   (test-suite
-    "sandboxed evaluation"
-    (test-not-exn "Plays well with sandboxed evaluation"
-                  ;; This test reproduces the bug and the fix fixes it. Yet,
-                  ;; coverage does not show the lambda in `my-emit-local-step`
-                  ;; as being covered. This could be because the constructed
-                  ;; sandbox evaluator "covering" the code doesn't count as
-                  ;; coverage by the main evaluator running the test?
-                  ;; We address this by putting `my-emit-local-step` in a
-                  ;; submodule, which, by default, are ignored by coverage.
-                  (lambda ()
-                    (let ([eval (make-evaluator
-                                 'racket/base
-                                 '(require qi))])
-                      (eval
-                       '(~> (3) (* 2) add1))))))))
+                   #'(~>> (filter odd?) values (map sqr)))))))))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -12,6 +12,7 @@
          syntax/macro-testing
          qi/flow/core/deforest
          qi/flow/core/compiler
+         racket/sandbox
          "private/deforest-util.rkt"
          (submod qi/flow/extended/expander invoke))
 
@@ -46,7 +47,46 @@
                (deforested?
                  (phase1-eval
                   (qi-compile
-                   #'(~>> (filter odd?) values (map sqr)))))))))
+                   #'(~>> (filter odd?) values (map sqr)))))))
+   (test-suite
+    "sandboxed evaluation"
+    (test-not-exn "Plays well with sandboxed evaluation"
+                  ;; This test reproduces the bug and the fix fixes it. Yet,
+                  ;; coverage does not show the lambda in `my-emit-local-step`
+                  ;; as being covered. This could be because the constructed
+                  ;; sandbox evaluator "covering" the code doesn't count as
+                  ;; coverage by the main evaluator running the test?
+                  ;; We address this by putting `my-emit-local-step` in a
+                  ;; submodule, which, by default, are ignored by coverage.
+                  (lambda ()
+                    (let ([eval (parameterize ([sandbox-output 'string]
+                                               [sandbox-error-output 'string]
+                                               [sandbox-memory-limit #f])
+                                  (make-evaluator
+                                   'racket/base
+                                   '(require (for-syntax racket/base)
+                                             ;; necessary to recognize and expand core forms correctly
+                                             qi/flow/extended/expander
+                                             ;; necessary to correctly expand the right-threading form
+                                             qi/flow/extended/forms
+                                             syntax/macro-testing
+                                             racket/list
+                                             qi/flow/core/compiler
+                                             (submod qi/flow/extended/expander invoke))
+
+                                   '(begin-for-syntax
+                                      (require syntax/parse/define
+                                               (for-template qi/flow/core/compiler)
+                                               (for-syntax racket/base))
+
+                                      ;; A macro that expands and compiles surface syntax
+                                      (define-syntax-parse-rule (qi-compile stx)
+                                        (compile-flow
+                                         (expand-flow stx))))))])
+                      (eval
+                       '(phase1-eval
+                         (qi-compile
+                          #'sqr)))))))))
 
 (module+ main
   (void

--- a/qi-test/tests/compiler/rules/full-cycle.rkt
+++ b/qi-test/tests/compiler/rules/full-cycle.rkt
@@ -17,10 +17,6 @@
          (submod qi/flow/extended/expander invoke))
 
 (begin-for-syntax
-  (require syntax/parse/define
-           (for-template qi/flow/core/compiler)
-           (for-syntax racket/base))
-
   ;; A function that expands and compiles surface syntax
   (define (qi-compile stx)
     (compile-flow


### PR DESCRIPTION
### Summary of Changes

This adds a regression test for the [recent issue](https://github.com/drym-org/qi/wiki/Qi-Meeting-Mar-29-2024) where building docs for packages depending on Qi was failing due to the use of macro introspection functionality in the `macro-debugger` library inside a sandboxed evaluator.

Although the test validates the bug as well as the fix, the coverage checker was still showing the `lambda` used in "monkey patching" the macro debugger utility as _uncovered_ by tests. My guess is that this is because the coverage tool only counts code as covered if the evaluator used in the test runner evaluates those lines, whereas in the present case, the code is "covered" by a sandboxed evaluator we construct in the test rather than the test runner itself.

Assuming this is the right explanation, I've placed the original fix inside a submodule -- by default, the coverage checker [ignores all submodules](https://docs.racket-lang.org/cover/api.html#%28def._%28%28lib._cover%2Fmain..rkt%29._irrelevant-submodules%29%29) for the purposes of coverage. So in cases where we are sure some code needn't be covered (or which we know is covered but isn't detected, as in this case), we can use this recipe as a standard way to add an exclusion to coverage.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
