### PR TITLE
Lambda core form

### DIFF
--- a/qi-doc/scribblings/forms.scrbl
+++ b/qi-doc/scribblings/forms.scrbl
@@ -100,6 +100,20 @@ The core syntax of the Qi language. These forms may be used in any @tech{flow}. 
   ]
 }
 
+@deftogether[(
+  @defform[(lambda expr ...)]
+  @defform[(λ expr ...)]
+)]{
+  Shorthand for @racket[(esc (lambda ...))].
+
+That is, this lambda is a @emph{Qi} form that expands to a use of @emph{Racket}'s lambda form, providing a shorthand for a common way to describe a flow using Racket.
+
+@examples[
+    #:eval eval-for-docs
+    ((☯ (λ (x) (+ 2 x))) 3)
+  ]
+}
+
 @defform[(clos flo)]{
   A @tech{flow} that generates a flow as a value. Any inputs to the @racket[clos] flow are available to @racket[flo] when it is applied to inputs, i.e. it is analogous to a @hyperlink["https://www.gnu.org/software/guile/manual/html_node/Closure.html"]{closure} in Racket.
 

--- a/qi-lib/flow/core/private/form-property.rkt
+++ b/qi-lib/flow/core/private/form-property.rkt
@@ -18,8 +18,7 @@
 
 (provide form-position?
          attach-form-property
-         tag-form-syntax
-         get-form-property)
+         tag-form-syntax)
 
 (require (only-in racket/function
                   curry))
@@ -42,9 +41,6 @@
 
 (define (attach-form-property stx)
   (syntax-property stx 'nonterminal 'floe))
-
-(define (get-form-property stx)
-  (syntax-property stx 'nonterminal))
 
 ;; This traverses a syntax object and indiscriminately tags every node
 ;; as a form. If this operation were applied to syntax in the real

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -182,6 +182,10 @@ core language's use of #%app, etc.).
     clos
     (clos onex:closed-floe)
     (esc ex:racket-expr)
+    (~> ((~literal lambda) e ...)
+        #'(esc (lambda e ...)))
+    (~> ((~literal λ) e ...)
+        #'(lambda e ...))
 
     ;; core form to express deforestable operations
     (#%deforestable name:id info:id e:deforestable-clause ...)

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -286,6 +286,11 @@
                    10
                    "normal racket expressions"))
     (test-suite
+     "lambda escape shortcut"
+     (check-equal? ((☯ (lambda (v) v)) 3) 3)
+     (check-equal? ((☯ (λ (v) v)) 3) 3)
+     (check-equal? ((☯ (λ () 3))) 3))
+    (test-suite
      "elementary boolean gates"
      (test-suite
       "AND"


### PR DESCRIPTION
### Summary of Changes

We discussed this in [last week's Qi meeting](https://github.com/drym-org/qi/wiki/Qi-Meeting-Jun-21-2024#a-better-remedy). A couple more thoughts:

Using a `lambda` in a `floe` position is likely to be a common syntax error in practice today (although I'm hard pressed to come up with an example where we really should be using a lambda rather than a flow, aside from wanting a different order of effects..). That would seem to support that we should allow this natural tendency by recognizing it as a shorthand way to escape to Racket. On the other hand, it could lull the user into a belief that they are writing `expr` syntax in this position rather than `floe`, which may cause confusion if they try to write other Racket forms without escaping them. I'm not too worried myself, but mentioning it in case anyone else has any thoughts on it.

This also removes an unused utility that I noticed was showing as uncovered by tests.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
