### PR TITLE
Defining deforestable operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ test:
 test-flow:
 	racket -y $(PACKAGE-NAME)-test/tests/flow.rkt
 
+test-list:
+	racket -y $(PACKAGE-NAME)-test/tests/list.rkt
+
 test-on:
 	racket -y $(PACKAGE-NAME)-test/tests/on.rkt
 

--- a/qi-lib/flow/aux-syntax.rkt
+++ b/qi-lib/flow/aux-syntax.rkt
@@ -3,10 +3,12 @@
 (provide literal
          subject
          clause
-         starts-with)
+         starts-with
+         (struct-out deforestable-info))
 
 (require syntax/parse
-         racket/string)
+         racket/string
+         (for-syntax racket/base))
 
 (define-syntax-class literal
   (pattern
@@ -56,3 +58,11 @@
             (symbol->string
              (syntax-e #'i))
             pfx)))
+
+;; A datatype used at compile time to convey user-defined data through
+;; the various stages of compilation for the purposes of extending Qi
+;; deforestation to custom list operations. It is currently used to
+;; convey a Racket runtime for macros in qi/list through to the code
+;; generation stage of Qi compilation (and could be used by any similar
+;; "deep" macros written by users).
+(struct deforestable-info [codegen])

--- a/qi-lib/flow/core/compiler/1000-qi0.rkt
+++ b/qi-lib/flow/core/compiler/1000-qi0.rkt
@@ -400,13 +400,11 @@ the DSL.
 
   (define (deforestable2-parser e)
     (syntax-parse e
-      #:datum-literals (#%optimizable-app)
-      [((~datum #%deforestable2) _name info c ...)
-       (let ([es^ (map deforestable2-clause-parser (attribute c))]
-             [info (syntax-local-value #'info)])
-         (match info
-           [(deforestable-info codegen)
-            (apply codegen es^)]))]))
+      #:datum-literals (#%deforestable2)
+      [(#%deforestable2 _name info c ...)
+       (let ([es^ (map deforestable2-clause-parser (attribute c))])
+         (match-let ([(deforestable-info codegen) (syntax-local-value #'info)])
+           (apply codegen es^)))]))
 
   (define (deforestable-parser stx)
     (syntax-parse stx

--- a/qi-lib/flow/core/compiler/1000-qi0.rkt
+++ b/qi-lib/flow/core/compiler/1000-qi0.rkt
@@ -401,12 +401,12 @@ the DSL.
   (define (deforestable2-parser e)
     (syntax-parse e
       #:datum-literals (#%optimizable-app)
-      [((~datum #%deforestable2) op c ...)
-       (define es^ (map deforestable2-clause-parser (attribute c)))
-       (define info (syntax-local-value #'op))
-       (match info
-         [(deforestable-info codegen)
-          (apply codegen es^)])]))
+      [((~datum #%deforestable2) _name info c ...)
+       (let ([es^ (map deforestable2-clause-parser (attribute c))]
+             [info (syntax-local-value #'info)])
+         (match info
+           [(deforestable-info codegen)
+            (apply codegen es^)]))]))
 
   (define (deforestable-parser stx)
     (syntax-parse stx

--- a/qi-lib/flow/core/compiler/1000-qi0.rkt
+++ b/qi-lib/flow/core/compiler/1000-qi0.rkt
@@ -94,7 +94,6 @@
     [(~datum appleye)
      #'call]
     [e:clos-form (clos-parser #'e)]
-    [e:deforestable2-form (deforestable2-parser #'e)]
     [e:deforestable-form (deforestable-parser #'e)]
     ;; escape hatch for racket expressions or anything
     ;; to be "passed through"
@@ -393,57 +392,18 @@ the DSL.
                (qi0->racket (~> (-< (~> (gen args) △) _)
                                 onex))))]))
 
-  (define (deforestable2-clause-parser c)
+  (define (deforestable-clause-parser c)
     (syntax-parse c
       [((~datum f) e) #'(qi0->racket e)]
       [((~datum e) e) #'e]))
 
-  (define (deforestable2-parser e)
+  (define (deforestable-parser e)
     (syntax-parse e
-      #:datum-literals (#%deforestable2)
-      [(#%deforestable2 _name info c ...)
-       (let ([es^ (map deforestable2-clause-parser (attribute c))])
+      #:datum-literals (#%deforestable)
+      [(#%deforestable _name info c ...)
+       (let ([es^ (map deforestable-clause-parser (attribute c))])
          (match-let ([(deforestable-info codegen) (syntax-local-value #'info)])
            (apply codegen es^)))]))
-
-  (define (deforestable-parser stx)
-    (syntax-parse stx
-      [((~datum #%deforestable) (~datum filter) (proc:clause))
-       #'(lambda (v)
-           (filter (qi0->racket proc) v))]
-      [((~datum #%deforestable) (~datum filter-map) (proc:clause))
-       #'(lambda (v)
-           (filter-map (qi0->racket proc) v))]
-      [((~datum #%deforestable) (~datum map) (proc:clause))
-       #'(lambda (v)
-           (map (qi0->racket proc) v))]
-      [((~datum #%deforestable) (~datum foldl) (proc:clause) (init:expr))
-       #'(lambda (v)
-           (foldl (qi0->racket proc) init v))]
-      [((~datum #%deforestable) (~datum foldr) (proc:clause) (init:expr))
-       #'(lambda (v)
-           (foldr (qi0->racket proc) init v))]
-      [((~datum #%deforestable) (~datum range) () (arg:expr ...))
-       #'(lambda ()
-           (range arg ...))]
-      [((~datum #%deforestable) (~datum take) () (n:expr))
-       #'(lambda (v)
-           (take v n))]
-      [((~datum #%deforestable) (~datum car))
-       #'car]
-      [((~datum #%deforestable) (~datum cadr))
-       #'cadr]
-      [((~datum #%deforestable) (~datum caddr))
-       #'caddr]
-      [((~datum #%deforestable) (~datum cadddr))
-       #'cadddr]
-      [((~datum #%deforestable) (~datum list-ref) () (n:expr))
-       #'(lambda (v)
-           (list-ref v n))]
-      [((~datum #%deforestable) (~datum length))
-       #'length]
-      [((~datum #%deforestable) (~or* (~datum empty?) (~datum null?)))
-       #'empty?]))
 
   (define (blanket-template-form-parser stx)
     (syntax-parse stx

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -93,7 +93,7 @@
   #:attributes (f)
   #:literal-sets (fs-literals)
   #:datum-literals (filter-map)
-  (pattern (#%deforestable filter-map (f-uncompiled))
+  (pattern (#%deforestable2 filter-map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-take

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -126,7 +126,7 @@
   #:datum-literals (foldr)
   (pattern (#%deforestable2
             foldr
-            _name
+            _info
             ((~datum f) op-uncompiled)
             ((~datum e) init))
     #:attr op (run-passes #'op-uncompiled)))
@@ -137,7 +137,7 @@
   #:datum-literals (foldl)
   (pattern (#%deforestable2
             foldl
-            _name
+            _info
             ((~datum f) op-uncompiled)
             ((~datum e) init))
     #:attr op (run-passes #'op-uncompiled)))

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -34,7 +34,7 @@
 
 ;; Literals set used for matching Fusable Stream Literals
 (define-literal-set fs-literals
-  #:datum-literals (esc #%host-expression #%fine-template #%blanket-template _ __)
+  #:datum-literals (esc #%host-expression #%fine-template #%blanket-template #%deforestable _ __)
   ())
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -49,7 +49,7 @@
 (define-syntax-class fsp-range
   #:attributes (blanket? fine? arg pre-arg post-arg)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable range)
+  #:datum-literals (range)
   (pattern (#%deforestable range _info ((~datum e) the-arg) ...)
     #:attr arg #'(the-arg ...)
     #:attr pre-arg #f
@@ -78,28 +78,28 @@
 (define-syntax-class fst-filter
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable filter)
+  #:datum-literals (filter)
   (pattern (#%deforestable filter _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-map
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable map)
+  #:datum-literals (map)
   (pattern (#%deforestable map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-filter-map
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable filter-map)
+  #:datum-literals (filter-map)
   (pattern (#%deforestable filter-map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-take
   #:attributes (n)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable take)
+  #:datum-literals (take)
   (pattern (#%deforestable take _info ((~datum e) n))))
 
 (define-syntax-class fst-syntax0
@@ -123,7 +123,7 @@
 (define-syntax-class fsc-foldr
   #:attributes (op init)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable foldr)
+  #:datum-literals (foldr)
   (pattern (#%deforestable
             foldr
             _info
@@ -134,7 +134,7 @@
 (define-syntax-class fsc-foldl
   #:attributes (op init)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable foldl)
+  #:datum-literals (foldl)
   (pattern (#%deforestable
             foldl
             _info
@@ -153,7 +153,7 @@
 (define-syntax-class fsc-list-ref
   #:attributes (pos name)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable list-ref)
+  #:datum-literals (list-ref)
   ;; TODO: need #%host-expression wrapping idx?
   (pattern (#%deforestable list-ref _info ((~datum e) idx))
     #:attr pos #'idx
@@ -165,12 +165,12 @@
 
 (define-syntax-class fsc-length
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable length)
+  #:datum-literals (length)
   (pattern (#%deforestable length _info)))
 
 (define-syntax-class fsc-empty?
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable empty?) ; note: null? expands to empty?
+  #:datum-literals (empty?) ; note: null? expands to empty?
   (pattern (#%deforestable empty? _info)))
 
 (define-syntax-class fsc-default

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -79,8 +79,9 @@
   #:attributes (f)
   #:literal-sets (fs-literals)
   #:datum-literals (filter)
-  (pattern (#%deforestable filter (f-uncompiled))
+  (pattern (#%deforestable2 filter _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
+
 (define-syntax-class fst-map
   #:attributes (f)
   #:literal-sets (fs-literals)

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -85,7 +85,7 @@
   #:attributes (f)
   #:literal-sets (fs-literals)
   #:datum-literals (map)
-  (pattern (#%deforestable map (f-uncompiled))
+  (pattern (#%deforestable2 map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-filter-map

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -170,9 +170,8 @@
 
 (define-syntax-class fsc-empty?
   #:literal-sets (fs-literals)
-  #:datum-literals (null? empty?)
-  (pattern (#%deforestable (~or empty?
-                                null?))))
+  #:datum-literals (#%deforestable2 empty?) ; note: null? expands to empty?
+  (pattern (#%deforestable2 empty? _info)))
 
 (define-syntax-class fsc-default
   #:datum-literals (cstream->list)

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -49,8 +49,8 @@
 (define-syntax-class fsp-range
   #:attributes (blanket? fine? arg pre-arg post-arg)
   #:literal-sets (fs-literals)
-  #:datum-literals (range)
-  (pattern (#%deforestable range () (the-arg ...))
+  #:datum-literals (#%deforestable2 range2)
+  (pattern (#%deforestable2 range2 _info ((~datum e) the-arg) ...)
     #:attr arg #'(the-arg ...)
     #:attr pre-arg #f
     #:attr post-arg #f

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -49,8 +49,8 @@
 (define-syntax-class fsp-range
   #:attributes (blanket? fine? arg pre-arg post-arg)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 range2)
-  (pattern (#%deforestable2 range2 _info ((~datum e) the-arg) ...)
+  #:datum-literals (#%deforestable2 range)
+  (pattern (#%deforestable2 range _info ((~datum e) the-arg) ...)
     #:attr arg #'(the-arg ...)
     #:attr pre-arg #f
     #:attr post-arg #f

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -165,8 +165,8 @@
 
 (define-syntax-class fsc-length
   #:literal-sets (fs-literals)
-  #:datum-literals (length)
-  (pattern (#%deforestable length)))
+  #:datum-literals (#%deforestable2 length)
+  (pattern (#%deforestable2 length _info)))
 
 (define-syntax-class fsc-empty?
   #:literal-sets (fs-literals)

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -100,7 +100,7 @@
   #:attributes (n)
   #:literal-sets (fs-literals)
   #:datum-literals (take)
-  (pattern (#%deforestable take () ((#%host-expression n)))))
+  (pattern (#%deforestable2 take _info ((~datum e) n))))
 
 (define-syntax-class fst-syntax0
   (pattern (~or _:fst-filter

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -144,17 +144,18 @@
 
 (define-syntax-class cad*r-datum
   #:attributes (countdown)
-  (pattern (#%deforestable (~datum car)) #:attr countdown #'0)
-  (pattern (#%deforestable (~datum cadr)) #:attr countdown #'1)
-  (pattern (#%deforestable (~datum caddr)) #:attr countdown #'2)
-  (pattern (#%deforestable (~datum cadddr)) #:attr countdown #'3))
+  #:datum-literals (#%deforestable2 car cadr caddr cadddr)
+  (pattern (#%deforestable2 car _info) #:attr countdown #'0)
+  (pattern (#%deforestable2 cadr _info) #:attr countdown #'1)
+  (pattern (#%deforestable2 caddr _info) #:attr countdown #'2)
+  (pattern (#%deforestable2 cadddr _info) #:attr countdown #'3))
 
 (define-syntax-class fsc-list-ref
   #:attributes (pos name)
   #:literal-sets (fs-literals)
-  #:datum-literals (list-ref)
+  #:datum-literals (#%deforestable2 list-ref)
   ;; TODO: need #%host-expression wrapping idx?
-  (pattern (#%deforestable list-ref () (idx))
+  (pattern (#%deforestable2 list-ref _info ((~datum e) idx))
     #:attr pos #'idx
     #:attr name #'list-ref)
   ;; TODO: bring wrapping #%deforestable out here?

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -49,8 +49,8 @@
 (define-syntax-class fsp-range
   #:attributes (blanket? fine? arg pre-arg post-arg)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 range)
-  (pattern (#%deforestable2 range _info ((~datum e) the-arg) ...)
+  #:datum-literals (#%deforestable range)
+  (pattern (#%deforestable range _info ((~datum e) the-arg) ...)
     #:attr arg #'(the-arg ...)
     #:attr pre-arg #f
     #:attr post-arg #f
@@ -78,29 +78,29 @@
 (define-syntax-class fst-filter
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 filter)
-  (pattern (#%deforestable2 filter _info ((~datum f) f-uncompiled))
+  #:datum-literals (#%deforestable filter)
+  (pattern (#%deforestable filter _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-map
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 map)
-  (pattern (#%deforestable2 map _info ((~datum f) f-uncompiled))
+  #:datum-literals (#%deforestable map)
+  (pattern (#%deforestable map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-filter-map
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 filter-map)
-  (pattern (#%deforestable2 filter-map _info ((~datum f) f-uncompiled))
+  #:datum-literals (#%deforestable filter-map)
+  (pattern (#%deforestable filter-map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-take
   #:attributes (n)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 take)
-  (pattern (#%deforestable2 take _info ((~datum e) n))))
+  #:datum-literals (#%deforestable take)
+  (pattern (#%deforestable take _info ((~datum e) n))))
 
 (define-syntax-class fst-syntax0
   (pattern (~or _:fst-filter
@@ -123,8 +123,8 @@
 (define-syntax-class fsc-foldr
   #:attributes (op init)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 foldr)
-  (pattern (#%deforestable2
+  #:datum-literals (#%deforestable foldr)
+  (pattern (#%deforestable
             foldr
             _info
             ((~datum f) op-uncompiled)
@@ -134,8 +134,8 @@
 (define-syntax-class fsc-foldl
   #:attributes (op init)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 foldl)
-  (pattern (#%deforestable2
+  #:datum-literals (#%deforestable foldl)
+  (pattern (#%deforestable
             foldl
             _info
             ((~datum f) op-uncompiled)
@@ -144,18 +144,18 @@
 
 (define-syntax-class cad*r-datum
   #:attributes (countdown)
-  #:datum-literals (#%deforestable2 car cadr caddr cadddr)
-  (pattern (#%deforestable2 car _info) #:attr countdown #'0)
-  (pattern (#%deforestable2 cadr _info) #:attr countdown #'1)
-  (pattern (#%deforestable2 caddr _info) #:attr countdown #'2)
-  (pattern (#%deforestable2 cadddr _info) #:attr countdown #'3))
+  #:datum-literals (#%deforestable car cadr caddr cadddr)
+  (pattern (#%deforestable car _info) #:attr countdown #'0)
+  (pattern (#%deforestable cadr _info) #:attr countdown #'1)
+  (pattern (#%deforestable caddr _info) #:attr countdown #'2)
+  (pattern (#%deforestable cadddr _info) #:attr countdown #'3))
 
 (define-syntax-class fsc-list-ref
   #:attributes (pos name)
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 list-ref)
+  #:datum-literals (#%deforestable list-ref)
   ;; TODO: need #%host-expression wrapping idx?
-  (pattern (#%deforestable2 list-ref _info ((~datum e) idx))
+  (pattern (#%deforestable list-ref _info ((~datum e) idx))
     #:attr pos #'idx
     #:attr name #'list-ref)
   ;; TODO: bring wrapping #%deforestable out here?
@@ -165,13 +165,13 @@
 
 (define-syntax-class fsc-length
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 length)
-  (pattern (#%deforestable2 length _info)))
+  #:datum-literals (#%deforestable length)
+  (pattern (#%deforestable length _info)))
 
 (define-syntax-class fsc-empty?
   #:literal-sets (fs-literals)
-  #:datum-literals (#%deforestable2 empty?) ; note: null? expands to empty?
-  (pattern (#%deforestable2 empty? _info)))
+  #:datum-literals (#%deforestable empty?) ; note: null? expands to empty?
+  (pattern (#%deforestable empty? _info)))
 
 (define-syntax-class fsc-default
   #:datum-literals (cstream->list)

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -124,20 +124,22 @@
   #:attributes (op init)
   #:literal-sets (fs-literals)
   #:datum-literals (foldr)
-  (pattern (#%deforestable
+  (pattern (#%deforestable2
             foldr
-            (op-uncompiled)
-            ((#%host-expression init)))
+            _name
+            ((~datum f) op-uncompiled)
+            ((~datum e) init))
     #:attr op (run-passes #'op-uncompiled)))
 
 (define-syntax-class fsc-foldl
   #:attributes (op init)
   #:literal-sets (fs-literals)
   #:datum-literals (foldl)
-  (pattern (#%deforestable
+  (pattern (#%deforestable2
             foldl
-            (op-uncompiled)
-            ((#%host-expression init)))
+            _name
+            ((~datum f) op-uncompiled)
+            ((~datum e) init))
     #:attr op (run-passes #'op-uncompiled)))
 
 (define-syntax-class cad*r-datum

--- a/qi-lib/flow/core/compiler/deforest/syntax.rkt
+++ b/qi-lib/flow/core/compiler/deforest/syntax.rkt
@@ -78,28 +78,28 @@
 (define-syntax-class fst-filter
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (filter)
+  #:datum-literals (#%deforestable2 filter)
   (pattern (#%deforestable2 filter _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-map
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (map)
+  #:datum-literals (#%deforestable2 map)
   (pattern (#%deforestable2 map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-filter-map
   #:attributes (f)
   #:literal-sets (fs-literals)
-  #:datum-literals (filter-map)
+  #:datum-literals (#%deforestable2 filter-map)
   (pattern (#%deforestable2 filter-map _info ((~datum f) f-uncompiled))
     #:attr f (run-passes #'f-uncompiled)))
 
 (define-syntax-class fst-take
   #:attributes (n)
   #:literal-sets (fs-literals)
-  #:datum-literals (take)
+  #:datum-literals (#%deforestable2 take)
   (pattern (#%deforestable2 take _info ((~datum e) n))))
 
 (define-syntax-class fst-syntax0
@@ -123,7 +123,7 @@
 (define-syntax-class fsc-foldr
   #:attributes (op init)
   #:literal-sets (fs-literals)
-  #:datum-literals (foldr)
+  #:datum-literals (#%deforestable2 foldr)
   (pattern (#%deforestable2
             foldr
             _info
@@ -134,7 +134,7 @@
 (define-syntax-class fsc-foldl
   #:attributes (op init)
   #:literal-sets (fs-literals)
-  #:datum-literals (foldl)
+  #:datum-literals (#%deforestable2 foldl)
   (pattern (#%deforestable2
             foldl
             _info

--- a/qi-lib/flow/core/syntax.rkt
+++ b/qi-lib/flow/core/syntax.rkt
@@ -18,8 +18,7 @@
          fold-right-form
          loop-form
          clos-form
-         deforestable-form
-         deforestable2-form)
+         deforestable-form)
 
 (require syntax/parse)
 
@@ -140,7 +139,3 @@ See comments in flow.rkt for more details.
 (define-syntax-class deforestable-form
   (pattern
    ((~datum #%deforestable) arg ...)))
-
-(define-syntax-class deforestable2-form
-  (pattern
-   ((~datum #%deforestable2) arg ...)))

--- a/qi-lib/flow/core/syntax.rkt
+++ b/qi-lib/flow/core/syntax.rkt
@@ -18,7 +18,8 @@
          fold-right-form
          loop-form
          clos-form
-         deforestable-form)
+         deforestable-form
+         deforestable2-form)
 
 (require syntax/parse)
 
@@ -139,3 +140,7 @@ See comments in flow.rkt for more details.
 (define-syntax-class deforestable-form
   (pattern
    ((~datum #%deforestable) arg ...)))
+
+(define-syntax-class deforestable2-form
+  (pattern
+   ((~datum #%deforestable2) arg ...)))

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -187,7 +187,7 @@ core language's use of #%app, etc.).
     (#%deforestable name:id (f:closed-floe ...) (arg:racket-expr ...))
     (#%deforestable name:id (f:closed-floe ...+))
     (#%deforestable name:id)
-    (#%deforestable2 name:id e:deforestable-clause ...)
+    (#%deforestable2 name:id info:id e:deforestable-clause ...)
 
     ;; backwards compat macro extensibility via Racket macros
     (~> ((~var ext-form (starts-with "qi:")) expr ...)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -184,10 +184,7 @@ core language's use of #%app, etc.).
     (esc ex:racket-expr)
 
     ;; core form to express deforestable operations
-    (#%deforestable name:id (f:closed-floe ...) (arg:racket-expr ...))
-    (#%deforestable name:id (f:closed-floe ...+))
-    (#%deforestable name:id)
-    (#%deforestable2 name:id info:id e:deforestable-clause ...)
+    (#%deforestable name:id info:id e:deforestable-clause ...)
 
     ;; backwards compat macro extensibility via Racket macros
     (~> ((~var ext-form (starts-with "qi:")) expr ...)

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -187,6 +187,7 @@ core language's use of #%app, etc.).
     (#%deforestable name:id (f:closed-floe ...) (arg:racket-expr ...))
     (#%deforestable name:id (f:closed-floe ...+))
     (#%deforestable name:id)
+    (#%deforestable2 name:id e:deforestable-clause ...)
 
     ;; backwards compat macro extensibility via Racket macros
     (~> ((~var ext-form (starts-with "qi:")) expr ...)
@@ -241,6 +242,10 @@ core language's use of #%app, etc.).
     (~> f:id
         #:with spaced-f (introduce-qi-syntax #'f)
         #'(esc spaced-f)))
+
+  (nonterminal deforestable-clause
+    ((~datum f) e:closed-floe)
+    ((~datum e) g:racket-expr))
 
   (nonterminal arg-stx
     (~datum _)

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -28,11 +28,15 @@
   #'(λ (vs)
       (r:filter-map f vs)))
 
-(define-qi-syntax-rule (foldl f:expr init:expr)
-  (#%deforestable foldl (f) (init)))
+(define-deforestable
+  (foldl [f f] [e init])
+  #'(λ (vs)
+      (r:foldl f init vs)))
 
-(define-qi-syntax-rule (foldr f:expr init:expr)
-  (#%deforestable foldr (f) (init)))
+(define-deforestable
+  (foldr [f f] [e init])
+  #'(λ (vs)
+      (r:foldr f init vs)))
 
 (define-qi-syntax-parser range
   [(_ low:expr high:expr step:expr) #'(#%deforestable range () (low high step))]

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -33,10 +33,14 @@
   #'(λ (vs)
       (r:foldr f init vs)))
 
+(define-deforestable (range2 [e low] [e high] [e step])
+  #'(λ ()
+      (r:range low high step)))
+
 (define-qi-syntax-parser range
-  [(_ low:expr high:expr step:expr) #'(#%deforestable range () (low high step))]
-  [(_ low:expr high:expr) #'(#%deforestable range () (low high 1))]
-  [(_ high:expr) #'(#%deforestable range () (0 high 1))]
+  [(_ low:expr high:expr step:expr) #'(range2 low high step)]
+  [(_ low:expr high:expr) #'(range2 low high 1)]
+  [(_ high:expr) #'(range2 0 high 1)]
   ;; not strictly necessary but this provides a better error
   ;; message than simply "range: bad syntax" that's warranted
   ;; to differentiate from racket/list's `range`

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -13,28 +13,23 @@
          (prefix-in r: racket/base)
          (prefix-in r: racket/list))
 
-(define-deforestable
-  (map [f f])
+(define-deforestable (map [f f])
   #'(lambda (vs)  ; single list arg
       (r:map f vs)))
 
-(define-deforestable
-  (filter [f f])
+(define-deforestable (filter [f f])
   #'(λ (vs)
       (r:filter f vs)))
 
-(define-deforestable
-  (filter-map [f f])
+(define-deforestable (filter-map [f f])
   #'(λ (vs)
       (r:filter-map f vs)))
 
-(define-deforestable
-  (foldl [f f] [e init])
+(define-deforestable (foldl [f f] [e init])
   #'(λ (vs)
       (r:foldl f init vs)))
 
-(define-deforestable
-  (foldr [f f] [e init])
+(define-deforestable (foldr [f f] [e init])
   #'(λ (vs)
       (r:foldr f init vs)))
 
@@ -49,8 +44,7 @@
           "(range arg ...)"
           "range expects at least one argument")])
 
-(define-deforestable
-  (take [e n])
+(define-deforestable (take [e n])
   #'(λ (vs)
       (r:take vs n)))
 

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -9,10 +9,13 @@
          "flow/extended/expander.rkt"
          (only-in "flow/space.rkt"
                   define-qi-alias)
-         "macro.rkt")
+         "macro.rkt"
+         (prefix-in r: racket/base))
 
-(define-qi-syntax-rule (map f:expr)
-  (#%deforestable map (f)))
+(define-deforestable
+  (map [f f])
+  #'(lambda (vs)  ; single list arg
+      (r:map f vs)))
 
 (define-qi-syntax-rule (filter f:expr)
   (#%deforestable filter (f)))

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -48,20 +48,21 @@
   #'(λ (vs)
       (r:take vs n)))
 
-(define-qi-syntax-parser car
-  [_:id #'(#%deforestable car)])
+(define-deforestable car
+  #'r:car)
 
-(define-qi-syntax-parser cadr
-  [_:id #'(#%deforestable cadr)])
+(define-deforestable cadr
+  #'r:cadr)
 
-(define-qi-syntax-parser caddr
-  [_:id #'(#%deforestable caddr)])
+(define-deforestable caddr
+  #'r:caddr)
 
-(define-qi-syntax-parser cadddr
-  [_:id #'(#%deforestable cadddr)])
+(define-deforestable cadddr
+  #'r:cadddr)
 
-(define-qi-syntax-rule (list-ref n:expr)
-  (#%deforestable list-ref () (n)))
+(define-deforestable (list-ref [e n])
+  #'(λ (vs)
+      (r:list-ref vs n)))
 
 (define-qi-syntax-parser length
   [_:id #'(#%deforestable length)])

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -10,7 +10,8 @@
          (only-in "flow/space.rkt"
                   define-qi-alias)
          "macro.rkt"
-         (prefix-in r: racket/base))
+         (prefix-in r: racket/base)
+         (prefix-in r: racket/list))
 
 (define-deforestable
   (map [f f])
@@ -22,8 +23,10 @@
   #'(λ (vs)
       (r:filter f vs)))
 
-(define-qi-syntax-rule (filter-map f:expr)
-  (#%deforestable filter-map (f)))
+(define-deforestable
+  (filter-map [f f])
+  #'(λ (vs)
+      (r:filter-map f vs)))
 
 (define-qi-syntax-rule (foldl f:expr init:expr)
   (#%deforestable foldl (f) (init)))

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -1,7 +1,10 @@
 #lang racket/base
 
 (provide (for-space qi
-                    (all-defined-out)))
+                    (except-out (all-defined-out)
+                                range2
+                                range)
+                    (rename-out [range2 range])))
 
 (require (for-syntax racket/base
                      "private/util.rkt")
@@ -33,14 +36,21 @@
   #'(λ (vs)
       (r:foldr f init vs)))
 
-(define-deforestable (range2 [e low] [e high] [e step])
+(define-deforestable (range [e low] [e high] [e step])
   #'(λ ()
       (r:range low high step)))
 
-(define-qi-syntax-parser range
-  [(_ low:expr high:expr step:expr) #'(range2 low high step)]
-  [(_ low:expr high:expr) #'(range2 low high 1)]
-  [(_ high:expr) #'(range2 0 high 1)]
+;; We'd like to indicate multiple surface variants for `range` that
+;; expand to a canonical form, and provide a single codegen just for the
+;; canonical form.
+;; Since `define-deforestable` doesn't support indicating multiple cases
+;; yet, we use the ordinary macro machinery to expand surface variants of
+;; `range` to a canonical form that is defined using
+;; `define-deforestable`.
+(define-qi-syntax-parser range2
+  [(_ low:expr high:expr step:expr) #'(range low high step)]
+  [(_ low:expr high:expr) #'(range low high 1)]
+  [(_ high:expr) #'(range 0 high 1)]
   ;; not strictly necessary but this provides a better error
   ;; message than simply "range: bad syntax" that's warranted
   ;; to differentiate from racket/list's `range`

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -49,8 +49,10 @@
           "(range arg ...)"
           "range expects at least one argument")])
 
-(define-qi-syntax-rule (take n:expr)
-  (#%deforestable take () (n)))
+(define-deforestable
+  (take [e n])
+  #'(λ (vs)
+      (r:take vs n)))
 
 (define-qi-syntax-parser car
   [_:id #'(#%deforestable car)])

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -64,8 +64,8 @@
   #'(λ (vs)
       (r:list-ref vs n)))
 
-(define-qi-syntax-parser length
-  [_:id #'(#%deforestable length)])
+(define-deforestable length
+  #'r:length)
 
 (define-qi-syntax-parser empty?
   [_:id #'(#%deforestable empty?)])

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -17,8 +17,10 @@
   #'(lambda (vs)  ; single list arg
       (r:map f vs)))
 
-(define-qi-syntax-rule (filter f:expr)
-  (#%deforestable filter (f)))
+(define-deforestable
+  (filter [f f])
+  #'(λ (vs)
+      (r:filter f vs)))
 
 (define-qi-syntax-rule (filter-map f:expr)
   (#%deforestable filter-map (f)))

--- a/qi-lib/list.rkt
+++ b/qi-lib/list.rkt
@@ -67,7 +67,7 @@
 (define-deforestable length
   #'r:length)
 
-(define-qi-syntax-parser empty?
-  [_:id #'(#%deforestable empty?)])
+(define-deforestable empty?
+  #'r:empty?)
 
 (define-qi-alias null? empty?)

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -118,20 +118,24 @@
     ;; to a corresponding number of clauses in the core form, like:
     ;; (op e1 e2 e3) → (#%optimizable-app #,info [f e1] [e e2] [f e3])
     (syntax-parse spec
-      [([tag arg-name] ...)
+      #:datum-literals (op)
+      [(op [tag arg-name] ...)
        (syntax-parser
          [(_ e ...+)
           #:fail-unless (= (length (attribute e))
                            (length (attribute arg-name)))
           "Wrong number of arguments!"
-          #`(#%deforestable #,name #,info [tag e] ...)]
-         ;; TODO, check: instead of `car`, does `(car)` produce
-         ;; a useful syntax error?
-         [_:id #`(#%deforestable #,name #,info)])])))
+          #`(#%deforestable #,name #,info [tag e] ...)])]
+      ;; TODO, check: instead of `car`, does `(car)` produce
+      ;; a useful syntax error?
+      ;; TODO: can add complementary error clauses in these two
+      ;; patterns; test that default errors are good enough. But if not
+      ;; can add the error clauses.
+      [op (syntax-parser [_:id #`(#%deforestable #,name #,info)])])))
 
 (define-syntax define-deforestable
   (syntax-parser
-    [(_ (name spec ...) codegen)
+    [(_ (name spec ...+) codegen)
      #:with ([typ arg] ...) #'(spec ...)
      #:with codegen-f #'(lambda (arg ...)
                           ;; var bindings vs pattern bindings
@@ -149,7 +153,7 @@
            (deforestable-info codegen-f))
 
          (define-dsl-syntax name qi-macro
-           (op-transformer #'name #'info #'(spec ...))))]
+           (op-transformer #'name #'info #'(op spec ...))))]
     [(_ name:id codegen)
      #:with codegen-f #'(lambda () codegen)
      #'(begin
@@ -160,4 +164,4 @@
            (deforestable-info codegen-f))
 
          (define-dsl-syntax name qi-macro
-           (op-transformer #'name #'info #'())))]))
+           (op-transformer #'name #'info #'op)))]))

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -120,12 +120,11 @@
     (syntax-parse spec
       [([tag arg-name] ...)
        (syntax-parser
-         [(_ e ...+) (if (= (length (attribute e))
-                            (length (attribute arg-name)))
-                         #`(#%deforestable2 #,name #,info [tag e] ...)
-                         (raise-syntax-error #f
-                                             "Wrong number of arguments!"
-                                             this-syntax))]
+         [(_ e ...+)
+          #:fail-unless (= (length (attribute e))
+                           (length (attribute arg-name)))
+          "Wrong number of arguments!"
+          #`(#%deforestable2 #,name #,info [tag e] ...)]
          ;; TODO, check: instead of `car`, does `(car)` produce
          ;; a useful syntax error?
          [_:id #`(#%deforestable2 #,name #,info)])])))

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -125,13 +125,18 @@
           #:fail-unless (= (length (attribute e))
                            (length (attribute arg-name)))
           "Wrong number of arguments!"
-          #`(#%deforestable #,name #,info [tag e] ...)])]
-      ;; TODO, check: instead of `car`, does `(car)` produce
-      ;; a useful syntax error?
-      ;; TODO: can add complementary error clauses in these two
-      ;; patterns; test that default errors are good enough. But if not
-      ;; can add the error clauses.
-      [op (syntax-parser [_:id #`(#%deforestable #,name #,info)])])))
+          #`(#%deforestable #,name #,info [tag e] ...)]
+         [_:id
+          (raise-syntax-error #f
+                              (format "Bad syntax. Usage: (~a arg ...)"
+                                      (syntax->datum this-syntax))
+                              this-syntax)])]
+      [op
+       (syntax-parser
+         ;; already raises a good error if used as a
+         ;; form with arguments (rather than as an identifier)
+         ;; so no special error handling needed here
+         [_:id #`(#%deforestable #,name #,info)])])))
 
 (define-syntax define-deforestable
   (syntax-parser

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -14,7 +14,7 @@
          (only-in "flow/extended/expander.rkt"
                   qi-macro
                   esc
-                  #%deforestable2)
+                  #%deforestable)
          qi/flow/space
          (for-syntax qi/flow/aux-syntax)
          syntax/parse/define
@@ -124,10 +124,10 @@
           #:fail-unless (= (length (attribute e))
                            (length (attribute arg-name)))
           "Wrong number of arguments!"
-          #`(#%deforestable2 #,name #,info [tag e] ...)]
+          #`(#%deforestable #,name #,info [tag e] ...)]
          ;; TODO, check: instead of `car`, does `(car)` produce
          ;; a useful syntax error?
-         [_:id #`(#%deforestable2 #,name #,info)])])))
+         [_:id #`(#%deforestable #,name #,info)])])))
 
 (define-syntax define-deforestable
   (syntax-parser

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -113,7 +113,7 @@
          ...)]))
 
 (begin-for-syntax
-  (define (op-transformer info spec)
+  (define (op-transformer name info spec)
     ;; use the `spec` to rewrite the source expression to expand
     ;; to a corresponding number of clauses in the core form, like:
     ;; (op e1 e2 e3) → (#%optimizable-app #,info [f e1] [e e2] [f e3])
@@ -122,7 +122,7 @@
        (syntax-parser
          [(_ e ...) (if (= (length (attribute e))
                            (length (attribute arg-name)))
-                        #`(#%deforestable2 #,info [tag e] ...)
+                        #`(#%deforestable2 #,name #,info [tag e] ...)
                         (raise-syntax-error #f
                                             "Wrong number of arguments!"
                                             this-syntax))])])))
@@ -147,4 +147,4 @@
            (deforestable-info codegen-f))
 
          (define-dsl-syntax name qi-macro
-           (op-transformer #'info #'(spec ...))))]))
+           (op-transformer #'name #'info #'(spec ...))))]))

--- a/qi-test/tests/expander.rkt
+++ b/qi-test/tests/expander.rkt
@@ -105,10 +105,11 @@
                              (#%host-expression 1)
                              __))))
     (test-expand "#%deforestable"
-                 #'(#%deforestable name (_) (_))
+                 #'(#%deforestable name info (f 0) (e 0))
                  #'(#%deforestable name
-                                   (_)
-                                   ((#%host-expression _)))))
+                                   info
+                                   (f (gen (#%host-expression 0)))
+                                   (e (#%host-expression 0)))))
    (test-suite
     "utils"
     ;; this is just temporary until we properly track source expressions through

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -286,16 +286,6 @@
                    10
                    "normal racket expressions"))
     (test-suite
-     "#%deforestable"
-     (check-equal? ((☯ (#%deforestable filter (odd?))) (list 1 2 3)) (list 1 3))
-     (check-equal? ((☯ (#%deforestable map (sqr))) (list 1 2 3)) (list 1 4 9))
-     (check-equal? ((☯ (#%deforestable foldl (+) (0))) (list 1 2 3)) 6)
-     (check-equal? ((☯ (#%deforestable foldr (+) (0))) (list 1 2 3)) 6)
-     (check-equal? ((☯ (#%deforestable range () (3)))) (list 0 1 2))
-     (check-equal? ((☯ (#%deforestable range () (0 3)))) (list 0 1 2))
-     (check-equal? ((☯ (#%deforestable range () (0 5 2)))) (list 0 2 4))
-     (check-equal? ((☯ (#%deforestable take () (2))) (list 1 2 3)) (list 1 2)))
-    (test-suite
      "elementary boolean gates"
      (test-suite
       "AND"


### PR DESCRIPTION
### Summary of Changes

WIP to integrate the [proof-of-concept "deep macro" extension scheme](https://github.com/drym-org/qi/wiki/Qi-Meeting-Nov-15-2024) for deforestation.

Useful context: see the meeting notes, [No More Unknowns!](https://github.com/drym-org/qi/wiki/Qi-Meeting-Nov-22-2024)

Planned:

- [x] translate `map`
- [x] translate the remaining `qi/list` operations
- [x] rename `#%deforestable2` to `#%deforestable` (replacing it)
- [x] remove the codegen for `#%deforestable`, replacing it with the new version for `#%deforestable2`

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
