### PR TITLE
Update tutorial.scrbl to accommodate changes to Racket-templates

### DIFF
--- a/qi-doc/scribblings/tutorial.scrbl
+++ b/qi-doc/scribblings/tutorial.scrbl
@@ -27,10 +27,10 @@ This tutorial is distributed using the @seclink["top" #:indirect? #t #:doc '(lib
 
 @subsection[#:tag "tutorial-installation"]{Installation}
 
-If you don't already have @seclink["top" #:indirect? #t #:doc '(lib "from-template/scribblings/from-template.scrbl")]{Racket Templates} installed, you'll need to run this first:
+If you don't already have @seclink["top" #:indirect? #t #:doc '(lib "raco-new/scribblings/raco-new.scrbl")]{Racket Templates} installed, you'll need to run this first:
 
 @codeblock{
-  raco pkg install from-template
+  raco pkg install new
 }
 
 And then, downloading the tutorial is as simple as:

--- a/qi-doc/scribblings/tutorial.scrbl
+++ b/qi-doc/scribblings/tutorial.scrbl
@@ -23,7 +23,7 @@ They contain similar material, but the interactive version includes additional s
 
 @section{Interactive Tutorial}
 
-This tutorial is distributed using the @seclink["top" #:indirect? #t #:doc '(lib "from-template/scribblings/from-template.scrbl")]{Racket Templates} package, and contains the same material as the documentation-based tutorial, but also includes additional material such as exercises, all presented in an interactive format.
+This tutorial is distributed using the @seclink["top" #:indirect? #t #:doc '(lib "raco-new/scribblings/raco-new.scrbl")]{Racket Templates} package, and contains the same material as the documentation-based tutorial, but also includes additional material such as exercises, all presented in an interactive format.
 
 @subsection[#:tag "tutorial-installation"]{Installation}
 

--- a/qi-doc/scribblings/tutorial.scrbl
+++ b/qi-doc/scribblings/tutorial.scrbl
@@ -23,11 +23,11 @@ They contain similar material, but the interactive version includes additional s
 
 @section{Interactive Tutorial}
 
-This tutorial is distributed using the @seclink["top" #:indirect? #t #:doc '(lib "raco-new/scribblings/raco-new.scrbl")]{Racket Templates} package, and contains the same material as the documentation-based tutorial, but also includes additional material such as exercises, all presented in an interactive format.
+This tutorial is distributed using the @seclink["top" #:indirect? #t #:doc '(lib "new/scribblings/new.scrbl")]{Racket Templates} package, and contains the same material as the documentation-based tutorial, but also includes additional material such as exercises, all presented in an interactive format.
 
 @subsection[#:tag "tutorial-installation"]{Installation}
 
-If you don't already have @seclink["top" #:indirect? #t #:doc '(lib "raco-new/scribblings/raco-new.scrbl")]{Racket Templates} installed, you'll need to run this first:
+If you don't already have @seclink["top" #:indirect? #t #:doc '(lib "new/scribblings/new.scrbl")]{Racket Templates} installed, you'll need to run this first:
 
 @codeblock{
   raco pkg install new


### PR DESCRIPTION
from-template is now raco-new with the command `raco new`

https://github.com/racket-templates/raco-new/

https://github.com/racket-templates/raco-new/issues/28

### Summary of Changes

Adjust tutorial to accommodate changes in Racket-templates usage

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.


