### PR TITLE
Migrate to syntax-spec-v3

### DIFF
--- a/qi-doc/scribblings/principles.scrbl
+++ b/qi-doc/scribblings/principles.scrbl
@@ -143,7 +143,7 @@ All of this happens at @seclink["phases" #:doc '(lib "scribblings/guide/guide.sc
 
 Thus, Qi is a special kind of @seclink["Hosted_Languages"]{hosted language}, one that happens to have the same architecture as the host language, Racket, in terms of having distinct expansion and compilation steps. This gives it a lot of flexibility in its implementation, including allowing much of its surface syntax to be implemented as @seclink["Qi_Macros"]{Qi macros} (for instance, Qi's @racket[switch] expands to a use of Qi's @racket[if] just as Racket's @racket[cond] expands to a use of Racket's @racket[if]), allowing it to be naturally macro-extensible by users, and lending it the ability to @seclink["Don_t_Stop_Me_Now"]{perform optimizations on the core language} that allow idiomatic code to be performant.
 
-This architecture is achieved through the use of @seclink["top" #:indirect? #t #:doc '(lib "syntax-spec-v2/scribblings/main.scrbl")]{Syntax Spec}, following the general approach described in @hyperlink["https://dl.acm.org/doi/abs/10.1145/3674627"]{Compiled, Extensible, Multi-language DSLs (Ballantyne et. al.)} and @hyperlink["https://dl.acm.org/doi/abs/10.1145/3428297"]{Macros for Domain-Specific Languages (Ballantyne et. al.)}.
+This architecture is achieved through the use of @seclink["top" #:indirect? #t #:doc '(lib "syntax-spec-v3/scribblings/main.scrbl")]{Syntax Spec}, following the general approach described in @hyperlink["https://dl.acm.org/doi/abs/10.1145/3674627"]{Compiled, Extensible, Multi-language DSLs (Ballantyne et. al.)} and @hyperlink["https://dl.acm.org/doi/abs/10.1145/3428297"]{Macros for Domain-Specific Languages (Ballantyne et. al.)}.
 
 @section{The Qi Core Language}
 

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -5,7 +5,7 @@
          (all-from-out "flow/extended/expander.rkt")
          (all-from-out "flow/extended/forms.rkt"))
 
-(require syntax-spec-v2
+(require syntax-spec-v3
          (for-syntax racket/base
                      syntax/parse
                      (only-in "private/util.rkt"

--- a/qi-lib/flow/extended/expander.rkt
+++ b/qi-lib/flow/extended/expander.rkt
@@ -13,7 +13,7 @@
                                 [collect ▽]
                                 [NOT !])))
 
-(require syntax-spec-v2
+(require syntax-spec-v3
          "../space.rkt"
          (for-syntax "../aux-syntax.rkt"
                      "syntax.rkt"
@@ -50,7 +50,7 @@ core language's use of #%app, etc.).
     #:description "a flow expression"
 
     f:floe
-    #:binding (nest-one f []))
+    #:binding (nest f []))
 
   ;; "floe" stands for "FLOw Expression" and is a _nonterminal_ that
   ;; expresses valid syntax for Qi expressions. It's analogous
@@ -64,18 +64,18 @@ core language's use of #%app, etc.).
     #:binding-space qi
 
     (as v:racket-var ...+)
-    #:binding (scope (bind v) nested)
+    #:binding (scope (bind v) ... nested)
 
     (thread f:floe ...)
-    #:binding (nest f nested)
+    #:binding (nest f ... nested)
 
     (tee f:floe ...)
-    #:binding (nest f nested)
+    #:binding (nest f ... nested)
     tee
     ;; Note: `#:binding nested` is the implicit binding rule here
 
     (relay f:floe ...)
-    #:binding (nest f nested)
+    #:binding (nest f ... nested)
     relay
 
     ;; [f nested] is the implicit binding rule
@@ -112,7 +112,7 @@ core language's use of #%app, etc.).
     (and f:closed-floe ...)
     (or f:closed-floe ...)
     (not f:floe)
-    #:binding (nest-one f nested)
+    #:binding (nest f nested)
     (all f:closed-floe)
     (any f:closed-floe)
     (select n:number ...)
@@ -127,7 +127,7 @@ core language's use of #%app, etc.).
     (fanout n:racket-expr)
     fanout
     (group n:racket-expr e1:floe e2:floe)
-    #:binding (nest-one e1 (nest-one e2 nested))
+    #:binding (nest e1 e2 nested)
     group
     (~>/form (group arg ...)
              (report-syntax-error this-syntax
@@ -137,8 +137,7 @@ core language's use of #%app, etc.).
     (if condition:floe
         consequent:closed-floe
         alternative:closed-floe)
-    #:binding (nest-one condition
-                        [consequent alternative nested])
+    #:binding (nest condition [consequent alternative nested])
     (sieve condition:closed-floe
            sonex:closed-floe
            ronex:closed-floe)

--- a/qi-lib/info.rkt
+++ b/qi-lib/info.rkt
@@ -4,7 +4,7 @@
 (define collection "qi")
 (define deps '("base"
                ("fancy-app" #:version "1.1")
-               "syntax-spec-v2"
+               "syntax-spec-v3"
                ;; we do need this, but it does need to be
                ;; dynamic-require'd, so raco doesn't see
                ;; it as a compile-time dependency

--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -19,7 +19,7 @@
          (for-syntax qi/flow/aux-syntax)
          syntax/parse/define
          syntax/parse
-         syntax-spec-v2)
+         syntax-spec-v3)
 
 (begin-for-syntax
 


### PR DESCRIPTION
### Summary of Changes

This just involves superficial changes to port to the `syntax-spec` form's new `binding-spec` notation.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
